### PR TITLE
Change preposition to 'sur'

### DIFF
--- a/src/_data/contribute.js
+++ b/src/_data/contribute.js
@@ -1,7 +1,7 @@
 module.exports = {
 	fr: {
 		contribute: "Contribuez",
-		small: "à Github.com",
+		small: "sur Github.com",
 		see: "Voir le code source",
 		report: "Signaler un problème",
 		join: "Participez aux discussions"


### PR DESCRIPTION
According to the [Banque de dépannage linguistique](http://bdl.oqlf.gouv.qc.ca/BDL/gabarit_bdl.asp?id=1638), we should use either "sur" or "dans" preposition when referring to websites in French.