### PR TITLE
Fixed links to 365 PowerPoint guides

### DIFF
--- a/src/en/guides/office365/accessible-excel-documents-365.html
+++ b/src/en/guides/office365/accessible-excel-documents-365.html
@@ -8,7 +8,7 @@ description: Accessible practices for Microsoft Excel document creation.
 	<ul class="toc lst-spcd col-md-12">
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-powerpoint-documents-365">3. Accessible PDF documents</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Accessible Excel documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>

--- a/src/en/guides/office365/accessible-pdf-documents-365.html
+++ b/src/en/guides/office365/accessible-pdf-documents-365.html
@@ -158,5 +158,5 @@ description: Accessible practices for PDF document creation.
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous"><a href="../accessible-word-documents-365" rel="prev">Previous: Accessible Word documents</a></li>
-	<li class="next"><a href="../accessible-powerpoint-documents-365" rel="next">Next: Accessible PDF documents</a></li>
+	<li class="next"><a href="../accessible-powerpoint-documents-365" rel="next">Next: Accessible PowerPoint documents</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-powerpoint-documents-365.html
+++ b/src/en/guides/office365/accessible-powerpoint-documents-365.html
@@ -8,7 +8,7 @@ description: Accessible practices for Microsoft PowerPoint document creation.
 	<ul class="toc lst-spcd col-md-12">
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-powerpoint-documents-365">3. Accessible PDF documents</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Accessible PowerPoint documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
@@ -366,6 +366,6 @@ description: Accessible practices for Microsoft PowerPoint document creation.
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous"><a href="../accessible-powerpoint-documents-365" rel="prev">Previous: Accessible PDF documents</a></li>
+	<li class="previous"><a href="../accessible-pdf-documents-365" rel="prev">Previous: Accessible PDF documents</a></li>
 	<li class="next"><a href="../accessible-excel-documents-365" rel="next">Next: Accessible Excel documents</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-visio-diagrams-365.html
+++ b/src/en/guides/office365/accessible-visio-diagrams-365.html
@@ -8,7 +8,7 @@ description: Accessible practices for Microsoft Visio diagram creation.
 	<ul class="toc lst-spcd col-md-12">
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-powerpoint-documents-365">3. Accessible PDF documents</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Accessible Visio diagrams</a></li>

--- a/src/en/guides/office365/accessible-word-documents-365.html
+++ b/src/en/guides/office365/accessible-word-documents-365.html
@@ -8,7 +8,7 @@ description: DESCRIPTION
 	<ul class="toc lst-spcd col-md-12">
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. Accessible Word documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-powerpoint-documents-365">3. Accessible PDF documents</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>


### PR DESCRIPTION
A number of links were pointing to the English 365 PowerPoint guides when they should have been pointing to the English 365 PDF guide.
