### PR TITLE
#68 multilang markup

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,6 +1,10 @@
 # Contributor Covenant Code of Conduct for the Digital Accessibility Toolkit project
 
+<div lang="fr">
+
 ([Français](#Code-de-conduite-pour-le-projet-boîte-à-outils-d'accessibilité-numérique))
+
+<div>
 
 Contributors to repositories hosted in Digital Accessibility Toolkit are expected to follow the Contributor Covenant Code of Conduct, and those working within Government are also expected to follow the Values and Ethics Code for the Public Sector
 
@@ -61,6 +65,9 @@ available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.h
 This Code of Conduct is also inspired by GDS' `alphagov` [Code of conduct](https://github.com/alphagov/code-of-conduct)
 
 ---
+
+<div lang="fr">
+
 <!--markdownlint-disable MD025-->
 # Code de conduite pour le projet Boîte à outils d'accessibilité numérique
 <!--markdownlint-enable MD025-->
@@ -120,3 +127,5 @@ disponible à l'adresse [https://www.contributor-covenant.org/version/1/4/code-o
 [page d'accueil]: https://www.contributor-covenant.org
 
 Le présent Code de conduite s'inspire également du " Code de conduite " du [alphaGov](https://github.com/alphagov/code-of-conduct) de GDS.
+
+</div>

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 ([Français](#Code-de-conduite-pour-le-projet-boîte-à-outils-d'accessibilité-numérique))
 
-<div>
+</div>
 
 Contributors to repositories hosted in Digital Accessibility Toolkit are expected to follow the Contributor Covenant Code of Conduct, and those working within Government are also expected to follow the Values and Ethics Code for the Public Sector
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing
 
+<div lang="fr">
+
 ([Français](#comment-contribuer))
+
+</div>
 
 <!-- Need to update this, suggestion to add stuff similar to https://www.a11yproject.com/contributing-guidelines/ -->
 
@@ -18,6 +22,8 @@ If this is your first time contributing on GitHub, don't worry! Let us know if y
 
 ______________________
 
+<div lang="fr">
+
 ## Comment contribuer
 
 Lorsque vous contribuez, veuillez également publier des commentaires et discuter des modifications que vous souhaitez apporter par l'entremise des enjeux (Issues).
@@ -29,3 +35,5 @@ Si c'est la première fois que vous contribuez à GitHub, ne vous en faites pas!
 ### Sécurité
 
 **Ne publiez aucun problème de sécurité sur le dépôt publique!** Voir [SECURITY.md](SECURITY.md)
+
+</div>

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,8 @@
+<div lang="fr">
+
 ([Français](#sécurité))
+
+</div>
 
 # Security
 
@@ -6,6 +10,10 @@
 
 ______________________
 
+<div lang="fr">
+
 ## Sécurité
 
 **Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées par courriel à ssc.aaact-aatia.spc@canada.ca
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+<div lang="fr">
+
 ([Français](#boîte-à-outils-d'accessibilité-numérique))
+
+</div>
+<div lang="en">
 
 This project is in the early stages of development and planning, not all information is available in both official languages.
 
@@ -46,7 +51,9 @@ Unless otherwise noted, the source code of this project is covered under Crown C
 
 The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program. For more information, see [Federal identity requirements](https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html).
 
+</div>
 ______________________
+<div lang="fr">
 
 ## Boîte à outils d'accessibilité numérique
 
@@ -83,3 +90,5 @@ Voir [CONTRIBUTING.md](.github/CONTRIBUTING.md) pour plus d'informations.
 Sauf indication contraire, le code source de ce projet est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué sous la [licence MIT](LICENSE).
 
 Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont protégés en vertu des lois portant sur les marques de commerce et le droit d'auteur. Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir davantage de renseignements à ce sujet, veuillez consulter les [Exigences pour l'image de marque](https://www.canada.ca/fr/secretariat-conseil-tresor/sujets/communications-gouvernementales/exigences-image-marque.html).
+
+</div>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ([Français](#boîte-à-outils-d'accessibilité-numérique))
 
 </div>
-<div lang="en">
 
 This project is in the early stages of development and planning, not all information is available in both official languages.
 
@@ -51,7 +50,6 @@ Unless otherwise noted, the source code of this project is covered under Crown C
 
 The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program. For more information, see [Federal identity requirements](https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html).
 
-</div>
 ______________________
 <div lang="fr">
 


### PR DESCRIPTION
## markdown pages language tagging

markdown pages need some french lang attribute so that they're being read properly.

**Related issues / Requêtes associées**
closes #68 

