### PR TITLE
Alert list: Specify translationText's language

### DIFF
--- a/src/_includes/partials/alerts.njk
+++ b/src/_includes/partials/alerts.njk
@@ -7,7 +7,7 @@
 		<li class="mrgn-tp-lg">{{ alerts[locale].draftText }}</li>
 	{% endif %}
 	{% if needsTranslation == true %}
-		<li class="mrgn-tp-lg">{{ alerts[locale].translationText }}</li>
+		<li class="mrgn-tp-lg" lang="{{ otherLang }}">{{ alerts[locale].translationText }}</li>
 	{% endif %}
 	</ul>
 </section>


### PR DESCRIPTION
## What does this pull request (PR) do?
Pages that use ``needsTranslation: true`` show an alert that contains the ``translationText`` string - which is written in the opposite of the page language.

This change programmatically-defines that string's language.

## Additional information

**General checklist**
- [x] Build and test PR's code
- [x] Validate changes against WCAG for accessibility

**Example of what this fixes:**
- https://a11y.canada.ca/8947/en/
Check the language of the second list item in the "Important notices" alert. It currently isn't specified, so it's being treated as English (despite being written in French).

**Other:**
- [gc-da11yn/wcag-issues](https://github.com/gc-da11yn/wcag-issues) has the same issue this PR is fixing. But none of that repo's pages currently use ``needsTranslation: true``.