### PR TITLE
Adding information about Accessibility Curriculum

### DIFF
--- a/src/en/curriculum/a11ycheck-nonweb.html
+++ b/src/en/curriculum/a11ycheck-nonweb.html
@@ -1,0 +1,87 @@
+---
+title: Accessibility Compliance Assessments checklist (non-web / software)
+layout: layouts/base.njk
+description: Accessibility resources for non-Web or software
+--- 
+<section>
+    <h2>1 &ndash; Keyboard related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.1 &ndash; Are there keyboard shortcuts available for all major functions of the software?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.2 &ndash; Is the Tab-Order in a logical left to right, top to bottom order?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.3 &ndash; Can all the controls be reached with the Tab key or other navigation keys without using a mouse (Ex:
+            F6 for task panes)?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.4 &ndash; Is there a well-defined visual focus indicator and insertion point that moves with standard keyboard
+            navigation controls?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.5 &ndash; Is there a keyboard navigation indicator (“_” - underlined access key) for every menu item and every
+            command control?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.6 &ndash; Is there a menu equivalent for every function found in all toolbars and format bars?</li>
+    </ul>
+</section>
+<section>
+    <h2>2 &ndash; Colours related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span> 2.1 Does the software use colour as an enhancement, not as the only way to convey information or indicate an
+            action?</li>
+    </ul>
+</section>
+<section>
+    <h2>3 &ndash; Cognitive related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>3.1 &ndash; Does the software avoid the use of acronyms that are not defined elsewhere?</li>
+    </ul>
+</section>
+<section>
+    <h2>4 &ndash; Outputs and Error Messages related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>4.1 &ndash; Can the documents be generated in more than one format?</li>
+    </ul>
+</section>
+<section>
+    <h2>5 &ndash; Screen Texts related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.1 &ndash; Does every window, object, and control have a clearly named label?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.2 &ndash; Do all toolbar controls have contextual help or ToolTips?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.3 &ndash; Does each dialog have a unique and significant title?</li>
+    </ul>
+</section>
+<section>
+    <h2>6 &ndash; Icons, Images and Cursor related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.1 &ndash; Does the software use the standard O/S icons for common functions (Ex: The diskette icon for Save)?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.2 &ndash; Does the software use the same icons throughout the software for the same functions?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.3 &ndash; Does the software avoid use of patterned backgrounds?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.4 &ndash; When images can be added, does the software allow a description of the image to be included?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.5 &ndash; Does the software use the O/S defined mouse cursors?</li>
+    </ul>
+</section>
+<section>
+    <h2>7 &ndash; Accessibility options related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>7.1 &ndash; Do the O/S accessibility features continue working when the software is running?</li>
+    </ul>
+</section>
+<section>
+    <h2>8 &ndash; Multimedia, sounds and animations related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.1 &ndash; Does the software have a visual or textual alternative for information that is available in audio
+            format?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.2 &ndash; Can the volume be changed or muted?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.3 &ndash; Does the software have textual description for video format?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.4 &ndash; Does the software allow animations to be disabled?</li>
+    </ul>
+</section>
+<section>
+    <h2>9 &ndash; Documentation related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.1 &ndash; Does the documentation clearly state all keyboard shortcuts that can be used with the software?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.2 &ndash; Does the documentation provide clear and precise step-by-step keyboard instructions for all the
+            functions of the program?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.3 &ndash; Does the documentation include text to describe images and videos?</li>
+    </ul>
+</section>
+<section>
+    <h2>10 &ndash; Timing related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>10.1 &ndash; Does the software avoid the use of blinking text, objects or other similar elements?</li>
+    </ul>
+</section>

--- a/src/en/curriculum/desktop-application-developer.html
+++ b/src/en/curriculum/desktop-application-developer.html
@@ -1,0 +1,254 @@
+---
+title: Desktop Application Developer
+layout: layouts/base.njk
+description: Accessibility courses for Desktop Application Developer
+--- 
+            <div class="well">
+                <ul>
+                    <li><a href="#301-549-video">EN 301 549 Video Series</a></li>
+                    <li><a href="#enabling-participation">Digital Accessibility: Enabling Participation in the Information Society</a></li>
+                    <li><a href="#accessible-instructional-design">Accessible instructional design <small>[variants: general, Adobe Captivate, Articulate Storyline, Blackboard]</small></a></li>
+                    <li><a href="#t716">T716: Web Accessibility for Canada.ca</a></li>
+                    <li><a href="#wcag-reading">Web Content Accessibility Guidelines (WCAG) 2.1 Self-paced - reading</a></li>
+                    <li><a href="#WET-styles">Web Experience Toolkit &ndash; Themes and Styles</a></li>
+                    <li><a href="#wet-plugins">Web Experience Toolkit &ndash; Plugins</a></li>
+                    <li><a href="#accessible-canada-act">Accessible Canada Act</a></li>
+                <li><a href="#accessibility-strategy">Accessibility Strategy for the Public Service of Canada</a></li>
+                <li><a href="#list">Accessibility Compliance Assessments Checklist (non-web / software)</a></li>
+                </ul>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="301-549-video" class="mrgn-tp-0">EN 301 549 Video Series</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>Description included in the video</dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org">YouTube Video</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>1.5 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online; Video</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Note:</dt>
+                        <dd>YouTube videos are accessible offline.</dd>
+                    </dl>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="enabling-participation" class="mrgn-tp-0">Digital Accessibility: Enabling Participation in the Information Society</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>This course will help you to understand how people with sensory, physical and cognitive impairments may be disabled by barriers encountered when using digital technologies. The course will highlight how the use of accessible and inclusive design can help overcome many of these difficulties.</dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.futurelearn.com/courses/digital-accessibility">Futurelearn</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>15 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online course</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Note:</dt>
+                        <dd>Currently not available</dd>
+                    </dl>
+                    <p><a href="https://www.futurelearn.com/courses/digital-accessibility" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Digital Accessibility: Enabling Participation in the Information Society</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-instructional-design" class="mrgn-tp-0">Accessible instructional design [variants: general, Adobe Captivate, Articulate Storyline, Blackboard]</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>Whether you use Adobe Captivate, Articulate Storyline, Studio, Canvas, Lectora, ATutor, or pure HTML5, we will de-mystify for you how you can delight your entire audience while conforming to regulations regarding accessibility for people living with disabilities. We'll even get into accessible SCORM and learning management systems (such as Blackboard and D2L). We can actually reduce our total cost and effort while creating better learning outcomes for all.</dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner; Instructional designers</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>One-day course, half-day course, or keynote presentation. We provide this course tailored/customized on-site for your organization).</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-for-instructional-design/" class="btn btn-success">Register<span class="wb-inv"> for Accessible instructional design</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="t716" class="mrgn-tp-0">T716: Web Accessibility for Canada.ca</h3>
+                    <p><strong>Note</strong>: Participants must have an account in order to access the course</p>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>This course presents the standards and guidelines for this subject. It focuses on the requirements, roles and responsibilities for compliance with these standards. Participants will learn how to assess the Web Content Accessibility Guidelines (WCAG) 2.1 and apply them consistently across Canada.ca web pages.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd>Canada School of Public Service</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Web Technical Information Specialist</dd>
+                        <dt>Duration:</dt>
+                        <dd>15 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Classroom courses</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language:</dt>
+                        <dd>English and French</dd>
+                    </dl>
+                    <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for T716</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="wcag-reading" class="mrgn-tp-0">Web Content Accessibility Guidelines (WCAG) 2.1 Self-paced - reading</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>Web Content Accessibility Guidelines (WCAG) 2.1 covers a wide range of recommendations for making Web content more accessible. These guidelines address accessibility of web content on desktops, laptops, tablets, and mobile devices.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd>World Wide Web Consortium (W3C)</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Not mentioned</dd>
+                        <dt>Duration:</dt>
+                        <dd>Self paced</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                    </dl>
+                    <p><a href="http://www.w3.org/TR/WCAG21/" class="btn btn-success">Read<span class="wb-inv">&nbsp;Web Content Accessibility Guidelines (WCAG) 2.1 Self-paced</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="WET-styles" class="mrgn-tp-0">Web Experience Toolkit &ndash; Themes and Styles</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>An <a href="https://wet-boew.github.io/wet-boew/docs/ref/accolades-en.html#awards">award-winning</a> front-end framework for building websites that are <a href="https://wet-boew.github.io/wet-boew/index-en.html#accessibility">accessible</a>, usable, <a href="https://wet-boew.github.io/wet-boew/index-en.html#interoperability">interoperable</a>, <a href="https://wet-boew.github.io/wet-boew/index-en.html#mobile-friendly-responsive-design">mobile friendly</a> and <a href="https://wet-boew.github.io/wet-boew/index-en.html#multilingual">multilingual</a></dd>
+                        <dt>Level:</dt>
+                        <dd>Any</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://wet-boew.github.io/wet-boew/index.html">Web Experience Toolkit</a> &ndash; a collaborative open source project led by the Government of Canada</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>Self paced</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Web</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                    </dl>
+                    <p><a href="https://wet-boew.github.io/wet-boew/index.html" class="btn btn-success">Read<span class="wb-inv">&nbsp;Web Experience Toolkit &ndash; Themes and Styles</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="wet-plugins" class="mrgn-tp-0">Web Experience Toolkit &ndash; Plugins</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>A WET plugin provides various types of functionality useful to a website and provided by calling the function in the class attribute of an HTML tag.</dd>
+                        <dt>Level:</dt>
+                        <dd>Any</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://wet-boew.github.io/wet-boew/index.html">Web Experience Toolkit</a> &ndash; a collaborative open source project led by the Government of Canada</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>Self pace reading</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Web</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                    </dl>
+                    <p><a href="https://wet-boew.github.io/wet-boew/index.html" class="btn btn-success">Read<span class="wb-inv">&nbsp;Web Experience Toolkit &ndash; Plugins</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-canada-act" class="mrgn-tp-0">Accessible Canada Act</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Provide a basis for understanding existing policies. Explain the purpose of the ACL and identify principles relevant to web application issues.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://laws-lois.justice.gc.ca/eng/">Justice Canada Website </a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration :</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://laws-lois.justice.gc.ca/eng/acts/A-0.6/" class="btn btn-success">Register<span class="wb-inv"> for Accessible Canada Act</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessibility-strategy" class="mrgn-tp-0">Accessibility Strategy for the Public Service of Canada</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Improve your understanding of the Government of Canada's desired state of technological accessibility for clients and employees. Explain what the Government of Canada is doing to improve accessibility using technology.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider :</dt>
+                        <dd><a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Web Site  </a></dd>
+                        <dt>Prerequisite :</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/accessibility-strategy-public-service-toc.html" class="btn btn-success">Read<span class="wb-inv"> for Accessibility Strategy for the Public Service of Canada</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="checklist" class="mrgn-tp-0">Accessibility Compliance Assessments Checklist (non-web / software)</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider :</dt>
+                        <dd>Employment and Social Development Canada website</dd>
+                        <dt>Prerequisite :</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery mode:</dt>
+                        <dd>Online tool</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>N/A</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="../../en/curriculum/a11ycheck-nonweb.html" class="btn btn-success">Read<span class="wb-inv"> Accessibility Compliance Assessments Checklist (non-web / software)</span></a></p>
+                </div>
+            </div>
+	

--- a/src/en/curriculum/desktop-application-tester.html
+++ b/src/en/curriculum/desktop-application-tester.html
@@ -1,0 +1,134 @@
+---
+title: Web Application Tester
+layout: layouts/base.njk
+description: Accessibility courses for Web Application Tester
+--- 
+<div class="well">
+    <ul>
+        <li><a href="#EN-301-549">EN 301-549 Non-Web Software (Chapter 11)</a></li>
+        <li><a href="#EN-301-549-video">EN 301 549 Video Series</a></li>
+        <li><a href="#accessible-canada-act">Accessible Canada Act</a></li>
+        <li><a href="#accessibility-strategy">Accessibility Strategy for the Public Service of Canada</a></li>
+        <li><a href="#list">Accessibility Compliance Assessments Checklist (non-web / software)</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="EN-301-549" class="mrgn-tp-0">EN 301-549 Non-Web Software (Chapter 11)</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>Accessibility requirements suitable for public procurement of ICT products and services in Europe" specifies the Functional Accessibility Requirements applicable to ICT products and services. It contains a description of the test procedures and evaluation methodology for each accessibility requirement. The requirements are suitable for use in public procurement within Europe.</dd>
+            <dt>Level:</dt>
+            <dd>Beginner</dd>
+            <dt>Provider:</dt>
+            <dd><a href="http://mandate376.standards.eu/">Accessible ICT Procurement Toolkit</a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>Not mentioned</dd>
+            <dt>Duration:</dt>
+            <dd>Self-paced</dd>
+            <dt>Delivery type:</dt>
+            <dd>Web</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+        </dl>
+        <p><a href="http://mandate376.standards.eu/standard/technical-requirements#11" class="btn btn-success">Read<span class="wb-inv">&nbsp;EN 301-549 Non-Web Software (Chapter 11)</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="EN-301-549-video" class="mrgn-tp-0">EN 301 549 Video Series</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>Understand the accessibility standard EN 301 549 which covers desktop applications (software), documentation and support services.  Explain the functional accessibility requirements for desktop applications, describe the testing procedures and evaluate the method for each accessibility requirement</dd>
+            <dt>Level:</dt>
+            <dd>Advanced</dd>
+            <dt>Provider:</dt>
+            <dd>YouTube</dd>
+            <dt>Duration:</dt>
+            <dd>1 hour</dd>
+            <dt>Delivery mode:</dt>
+            <dd>Online viewing</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language:</dt>
+            <dd>English</dd>
+            <dt>Note</dt>
+            <dd>YouTube videos are accessible offline.</dd>
+        </dl>
+        <p><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org/videos" class="btn btn-success">Watch<span class="wb-inv">&nbsp;EN 301 549 Video Series</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="accessible-canada-act" class="mrgn-tp-0">Accessible Canada Act</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>Provide a basis for understanding existing policies. Explain the purpose of the ACL and identify principles relevant to web application issues.</p>
+            </dd>
+            <dt>Level:</dt>
+            <dd>N/A</dd>
+            <dt>Provider:</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/eng/">Justice Canada Website </a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>None</dd>
+            <dt>Duration :</dt>
+            <dd>N/A</dd>
+            <dt>Delivery type:</dt>
+            <dd>Online reading</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language :</dt>
+            <dd>French or English</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/eng/acts/A-0.6/" class="btn btn-success">Register<span class="wb-inv"> for Accessible Canada Act</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="accessibility-strategy" class="mrgn-tp-0">Accessibility Strategy for the Public Service of Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>Improve your understanding of the Government of Canada's desired state of technological accessibility for clients and employees. Explain what the Government of Canada is doing to improve accessibility using technology.</p>
+            </dd>
+            <dt>Level:</dt>
+            <dd>N/A</dd>
+            <dt>Provider :</dt>
+            <dd><a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Web Site  </a></dd>
+            <dt>Prerequisite :</dt>
+            <dd>None</dd>
+            <dt>Duration:</dt>
+            <dd>N/A</dd>
+            <dt>Delivery type:</dt>
+            <dd>Online reading</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language :</dt>
+            <dd>French or English</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/accessibility-strategy-public-service-toc.html" class="btn btn-success">Read<span class="wb-inv"> for Accessibility Strategy for the Public Service of Canada</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="checklist" class="mrgn-tp-0">Accessibility Compliance Assessments Checklist (non-web / software)</h3>
+        <dl class="dl-horizontal">
+            <dt>Level:</dt>
+            <dd>N/A</dd>
+            <dt>Provider :</dt>
+            <dd>Employment and Social Development Canada website</dd>
+            <dt>Prerequisite :</dt>
+            <dd>None</dd>
+            <dt>Duration:</dt>
+            <dd>N/A</dd>
+            <dt>Delivery mode:</dt>
+            <dd>Online tool</dd>
+            <dt>Estimated cost:</dt>
+            <dd>N/A</dd>
+            <dt>Language :</dt>
+            <dd>French or English</dd>
+        </dl>
+        <p><a href="../../en/curriculum/a11ycheck-nonweb.html" class="btn btn-success">Read<span class="wb-inv"> Accessibility Compliance Assessments Checklist (non-web / software)</span></a></p>
+    </div>
+</div>

--- a/src/en/curriculum/index.html
+++ b/src/en/curriculum/index.html
@@ -1,0 +1,46 @@
+---
+title: Accessibility Curriculum
+layout: layouts/base.njk
+description: The Accessibility Curriculum is a list of courses that will provide knowledge of accessibility to better serve internal and external clients.
+---
+		<section>
+			<h2>Intention and vision for the accessibility curriculum</h2>
+			<p>The new <a href="https://www.parl.ca/DocumentViewer/en/42-1/bill/C-81/royal-assent"><em>Accessible Canada Act</em></a> will require Innovation, Information and Technology Branch (IITB) employees to be aware of their obligations to ensure an accessible work environment. The list of courses will provide an opportunity for employees to increase their knowledge of accessibility and to better serve internal and external clients. It will also be an opportunity for various target audiences such as Project Managers, IITB developers, programmers and technicians to proactively provide accessible services, software and programs that bring the greatest value to our colleagues who use ACT (adaptive computer technology).</p>
+			<section>
+				<h3>IITB's mandate:</h3>
+				<ul>
+					<li>To provide modern, secure, effective and efficient information and technology services that bring the greatest value to clients</li>
+					<li>To securely connect information and technology for clients, partnerships and citizens.</li>
+				</ul>
+			</section>
+			<section>
+				<h3>IT Accessibility's mandate:</h3>
+				<ul>
+					<li>To be a leader in accessibility, promoting and enabling an all-inclusive workplace and Service to ESDC employees by providing adaptive technology and accessible solutions.</li>
+				</ul>
+			</section>
+		<h3>Target learners</h3>
+		<ul>
+			<li>Accessibility has become one of Employment and Social Development Canada's top priorities, therefore training is for the following target audiences:
+				<ul>
+					<li>All CS01 and CS02 application developers and testers</li>
+					<li>CS03 team leads, project leads and IT specialists responsible for application development</li>
+					<li>ESDC management</li>
+					<li>Writers, editors and translators</li>
+					<li>All other ESDC employees</li>
+				</ul>
+			</li>
+		</ul>
+	</section>
+	<p>The total amount of time spent on training depends on each employee and his or her current knowledge of accessibility.</p>
+	<p>Some of the courses below are provided by external vendors and available only in English. Other courses are available via College@ESDC and Canada School of Public Service. ESDC makes no affiliation with these courses, does not maintain these Web sites, and therefore cannot be responsible for the content found therein. These Web sites are a resource and are to be used with caution.</p>
+
+	<ul class="lst-spcd">
+		<li><a href="http://iservice.prv/eng/college/intercultural-competence/accessibility.shtml">General Accessibility <i class="fas fa-external-link-square-alt" aria-hidden="true"></i><span class="wb-inv">Lien interne</span></a></li>
+		<li><a href="./web-application-developer.html">Web Application Developer</a></li>
+		<li><a href="./web-application-tester.html">Web Application Tester</a></li>
+		<li><a href="./desktop-application-developer.html">Desktop Application Developer</a></li>
+		<li><a href="./desktop-application-tester.html">Desktop Application Tester</a></li>
+		<li><a href="./writers-editors-translators.html">Writers, Editors and Translators</a></li>
+	</ul>
+	

--- a/src/en/curriculum/web-application-developer.html
+++ b/src/en/curriculum/web-application-developer.html
@@ -1,0 +1,311 @@
+---
+title: Web Application Developer
+layout: layouts/base.njk
+description: Accessibility courses for Web Application Developer
+---
+            <div class="well">
+                <ul>
+                    <li><a href="#t716">T716: Web Accessibility for Canada.ca</a></li>
+                    <li><a href="#web-accessibility-developers">Web Accessibility for Developers</a></li>
+                    <li><a href="#curriculum-package">Web Accessibility Curriculum Package</a></li>
+                    <li><a href="#whats-new-wcag">What's new in WCAG 2.1</a></li>
+                    <li><a href="#WCAG-deep-dive">WCAG Deep Dive for Web teams</a></li>
+                    <li><a href="#accessible-development">Accessible development for apps and mobile sites</a></li>
+                    <li><a href="#accessible-forms">Creating accessible forms: AcroForms and Adobe LiveCycle Designer</a></li>
+                    <li><a href="#InDesign">Creating accessible PDFs with Adobe InDesign</a></li>
+                    <li><a href="#audit">Professional Web Accessibility Auditing Made Easy </a></li>
+                    <li><a href="#accessible-canada-act">Accessible Canada Act</a></li>
+                <li><a href="#accessibility-strategy">Accessibility Strategy for the Public Service of Canada</a></li>
+                </ul>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="t716" class="mrgn-tp-0">T716: Web Accessibility for Canada.ca</h3>
+                    <p><strong>Note</strong>: Participants must have an account in order to access the course</p>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>This course presents the standards and guidelines for this subject. It focuses on the requirements, roles and responsibilities for compliance with these standards. Participants will learn how to assess the Web Content Accessibility Guidelines (WCAG) 2.1 and apply them consistently across Canada.ca web pages.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd>Canada School of Public Service</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Web Technical Information Specialist</dd>
+                        <dt>Duration:</dt>
+                        <dd>15 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Classroom courses</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language:</dt>
+                        <dd>English and French</dd>
+                    </dl>
+                    <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for T716</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="web-accessibility-developers" class="mrgn-tp-0">Web Accessibility for Developers</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>With the introduction of WAI-ARIA (Web Accessibility Initiative - Accessible Rich Internet Applications) Specification, developers can be much more creative when developing interactive elements for the Web than was possible before its advent. When WAI-ARIA is used with accessible JavaScript, the sky is the limit when it comes to potential interactions on the web, interactions that are also possible for those using assistive technology.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://de.ryerson.ca/wa/">Ryerson University</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>
+                            <ul>
+                                <li>Comfort developing with JavaScript, HTML5 and CSS</li>
+                                <li>A GitHub account</li>
+                                <li>A local development environment</li>
+                            </ul>
+                        </dd>
+                        <dt>Duration:</dt>
+                        <dd>37.5 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                    </dl>
+                    <p><a href="https://de.ryerson.ca/wa/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Web Accessibility for Developers</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="curriculum-package" class="mrgn-tp-0">Web Accessibility Curriculum Package</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>You will learn about the fundamentals of accessibility, standards and IT testing techniques. You will be able to provide advice and guidance on developing and testing accessibility in accessible web applications.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Advanced</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.deque.com/">Deque University</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online Courses</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>
+                            <p>$150 US <a href="https://dequeuniversity.com/scholarships">or free for people with disabilities</a>.</p>
+                        </dd>
+                    </dl>
+                    <p><a href="https://dequeuniversity.com/curriculum/packages/web" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Web Accessibility Curriculum Package</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="whats-new-wcag" class="mrgn-tp-0">What's new in WCAG 2.1</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <ul>
+                                <li>Know techniques you can apply right away</li>
+                                <li>Have a comprehensive understanding of W3C WCAG 2.1 and related government accessibility guidelines</li>
+                                <li>Be able to make informed decisions as to what degree to comply with accessibility standards</li>
+                                <li>Understand better the experience of those with disabilities using online learning, presentation, and authoring tools</li>
+                            </ul>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>WCAG 2.0 familiarity (no programming experience required)</dd>
+                        <dt>Duration:</dt>
+                        <dd>One-day course, half-day course, or keynote presentation. We provide this course tailored/customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/whats-new-in-wcag-2-1/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for What's new in WCAG 2.1</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="WCAG-deep-dive" class="mrgn-tp-0">WCAG Deep Dive for Web teams</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Participants leave with techniques they can use right away for authoring, designing, producing, and testing all relevant WCAG criteria.</p>
+                            <p>This course incorporates adult learning principles and activities appropriate to a variety of learning styles, and qualifies for CEUs (certified by organizations such as PPAC).</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Advanced</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Experience with HTML, CSS, and JavaScript/jQuery is required, experience with accessibility and WCAG 2.0 or 2.1 is recommended.</dd>
+                        <dt>Duration:</dt>
+                        <dd>1 or 2 days. We also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9DROsfSey1r-2FtJ718kbAvXIrEjHcSvXH67OamqnUutLzxl9qa4Pmv6EQWT6B0PNV-2B_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTt-2FodR-2Fhd7sYvnASOtAn4uFfvIND6qR5MkV-2FbClKaW-2Bnlc-2BL0hre-2FbOuMCVt5ql03kXJBvFEpKb2S-2BxwGHKOmsgbivypVWvtzVx2Bzp-2FOCSfPD8h7Oluqr-2B2bZD6gJmmwqwyhG8dLp-2B7wg1hqWHkOk1wYLv4hWxjUotBW4g6KL6M" class="btn btn-success">Register<span class="wb-inv">&nbsp;for WCAG Deep Dive for Web teams</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-development" class="mrgn-tp-0">Accessible development for apps and mobile sites</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>At the end of this event, you will:</p>
+                            <ul>
+                                <li>have a comprehensive understanding of the pertinent W3C WCAG 2 and current government accessibility policies, and how to meet them.</li>
+                                <li>be able to make informed decisions as to which content should go mobile.</li>
+                                <li>be able to make informed decisions as to when to go native vs. cross-platform for app development.</li>
+                            </ul>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>One-day course, half-day course, or keynote presentation. We also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online or onsite</dd>
+                        <dt>Estimated cost: </dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-for-mobile-tablets-and-touch/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Accessible development for apps and mobile sites</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-forms" class="mrgn-tp-0">Creating accessible forms: AcroForms and Adobe LiveCycle Designer</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>From fundamental techniques such as proper tagging and code structures, to advanced techniques including programmatic solutions to accessibility issues, this course provides designers and developers with the tools they need to meet WCAG conformance and functional accessibility with their PDF forms for both LiveCycle Designer (XFA) and AcroForms.</p>
+                            <p>Participants leave with techniques they can use right away for authoring, designing, producing, and testing all relevant WCAG criteria.</p>
+                            <p>This course incorporates adult learning principles and activities appropriate to a variety of learning styles, and qualifies for CEUs (certified by organizations such as PPAC).</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Experience with Acrobat AcroForms and/or LiveCycle Designer (XFA) forms is required, Experience with accessibility and WCAG 2.0 or 2.1 is recommended</dd>
+                        <dt>Duration:</dt>
+                        <dd>1 or 2 days</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online or onsite</dd>
+                        <dt>Estimated cost: </dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO98YowxLnjwsusP-2FRIJXFBVIAGd-2FwVi-2FpND1mWxUI2it4OY03nILGotvtSz2cGMsdh_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTsn3L0F44Yp34BPoB4S0wrdK7X4bUXc6wHhfrESHWknQqfJrFMR6wGeh-2Fz6fKUmwxuTOtHzqGaMLMZB9svKpAOzq1s9UnG2-2Bshd4Rhg0SPLPJdOCnGO1m0QU4M0X2CJDS7awY51i20yW85NmXSsLL84rZDQ0qwwslUoyf6yswP2k" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Creating accessible forms: AcroForms and Adobe LiveCycle Designer</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="InDesign" class="mrgn-tp-0">Creating accessible PDFs with Adobe InDesign</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>Upon completion, participants will be able to successfully create an accessible (WCAG and PDF/UA compliant) PDF using Adobe InDesign and Adobe Acrobat Pro.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>
+                            <ul>
+                                <li>Recommended pre-knowledge</li>
+                                <li>Familiarity with WCAG 2</li>
+                                <li>Familiarity with Adobe InDesign</li>
+                                <li>Familiarity with Adobe Acrobat Pro</li>
+                            </ul>
+                        </dd>
+                        <dt>Duration:</dt>
+                        <dd>1 day (5.5 instructional hours)</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd></dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessible-indesign-course/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Creating accessible PDFs with Adobe InDesign</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="InDesign" class="mrgn-tp-0">Professional Web Accessibility Auditing Made Easy </h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>You will be able to provide advice and guidance on auditing Web application accessibility compliance.</dd>
+                        <dt>Level:</dt>
+                        <dd>Advanced</dd>
+                        <dt>Provider:</dt>
+                        <dd>Ryerson University</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None
+                        </dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading (book to be downloaded)</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language:</dt>
+                        <dd>English</dd>
+                    </dl>
+                    <p><a href="https://pressbooks.library.ryerson.ca/pwaa" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Creating accessible PDFs with Adobe InDesign</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-canada-act" class="mrgn-tp-0">Accessible Canada Act</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Provide a basis for understanding existing policies. Explain the purpose of the ACL and identify principles relevant to web application issues.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://laws-lois.justice.gc.ca/eng/">Justice Canada Website </a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration :</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://laws-lois.justice.gc.ca/eng/acts/A-0.6/" class="btn btn-success">Read<span class="wb-inv"> Accessible Canada Act</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessibility-strategy" class="mrgn-tp-0">Accessibility Strategy for the Public Service of Canada</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Improve your understanding of the Government of Canada's desired state of technological accessibility for clients and employees. Explain what the Government of Canada is doing to improve accessibility using technology.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider :</dt>
+                        <dd><a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Web Site  </a></dd>
+                        <dt>Prerequisite :</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/accessibility-strategy-public-service-toc.html" class="btn btn-success">Read<span class="wb-inv"> for Accessibility Strategy for the Public Service of Canada</span></a></p>
+                </div>
+            </div>
+	

--- a/src/en/curriculum/web-application-tester.html
+++ b/src/en/curriculum/web-application-tester.html
@@ -1,0 +1,176 @@
+---
+title: Web Application Tester
+layout: layouts/base.njk
+description: Accessibility courses for Web Application Tester
+--- 
+<div class="well">
+    <ul>
+        <li><a href="#t716">T716: Web Accessibility for Canada.ca</a></li>
+        <li><a href="#301-549">EN 301-549 Non-Web Software (Chapter 11)</a></li>
+        <li><a href="#how-to-audit">How to audit: accessible QA for sites, apps, and documents</a></li>
+        <li><a href="#508-ada-testers">eAccessibility for Section 508 and ADA, and Trusted Testers</a></li>
+        <li><a href="#accessible-canada-act">Accessible Canada Act</a></li>
+    <li><a href="#accessibility-strategy">Accessibility Strategy for the Public Service of Canada</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="t716" class="mrgn-tp-0">T716: Web Accessibility for Canada.ca</h3>
+        <p><strong>Note</strong>: Participants must have an account in order to access the course</p>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>This course presents the standards and guidelines for this subject. It focuses on the requirements, roles and responsibilities for compliance with these standards. Participants will learn how to assess the Web Content Accessibility Guidelines (WCAG) 2.1 and apply them consistently across Canada.ca web pages.</dd>
+            <dt>Level:</dt>
+            <dd>Intermediate</dd>
+            <dt>Provider:</dt>
+            <dd>Canada School of Public Service</dd>
+            <dt>Prerequisite:</dt>
+            <dd>Web Technical Information Specialist</dd>
+            <dt>Duration:</dt>
+            <dd>15 hours</dd>
+            <dt>Delivery type:</dt>
+            <dd>Classroom courses</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language:</dt>
+            <dd>English and French</dd>
+        </dl>
+        <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for T716</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="301-549" class="mrgn-tp-0">EN 301-549 Non-Web Software (Chapter 11)</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>Accessibility requirements suitable for public procurement of ICT products and services in Europe" specifies the Functional Accessibility Requirements applicable to ICT products and services. It contains a description of the test procedures and evaluation methodology for each accessibility requirement. The requirements are suitable for use in public procurement within Europe.</dd>
+            <dt>Level:</dt>
+            <dd>Beginner</dd>
+            <dt>Provider:</dt>
+            <dd><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org">Accessible ICT Procurement Toolkit</a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>Not mentioned</dd>
+            <dt>Duration:</dt>
+            <dd>Self-paced</dd>
+            <dt>Delivery type:</dt>
+            <dd>Onlined; Reading</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Note:</dt>
+            <dd>YouTube videos are accessible offline.</dd>
+        </dl>
+        <p><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org" class="btn btn-success">Read<span class="wb-inv">&nbsp; EN 301-549 Non-Web Software (Chapter 11)</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="how-to-audit" class="mrgn-tp-0">How to audit: accessible QA for sites, apps, and documents</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>Instructional videos on the European standard for accessibility requirements in public procurement of ICT (Information Communication Technology) products and services. These videos are sponsored by Microsoft and produced by Funka</p>
+                <ul>
+                    <li>Accessibility quality assurance</li>
+                    <li>Accessibility supported technologies</li>
+                    <li>Standard controls vs. custom controls</li>
+                    <li>Strategies of persons with disabilities in using web solutions</li>
+                    <li>Interoperability and compatibility issues</li>
+                    <li>Testing with assistive technologies</li>
+                    <li>Testing for end-user impact</li>
+                    <li>Testing tools for the web (both automated and manual tools,</li>
+                    <li>Level of severity and prioritization of issues</li>
+                </ul>
+            </dd>
+            <dt>Level:</dt>
+            <dd>Intermediate</dd>
+            <dt>Provider:</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>Experience with HTML, CSS, and JavaScript/jQuery is required, experience with accessibility and WCAG 2.0 or 2.1 is recommended.</dd>
+            <dt>Duration:</dt>
+            <dd>half-day or full-day. We also provide this course customized on-site for your organization.</dd>
+            <dt>Delivery type:</dt>
+            <dd>online or onsite</dd>
+            <dt>Estimated cost:</dt>
+            <dd>CAD$330 (group discounts available)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9DJWk5al2cBTBls5C7KCtdS2TWLcMuLKWSU3fnqFeXcw-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTu8opZhDf9tpc-2FyXZ8URStdJ2bfsUQTYZT-2B2D9Dlq25G9ljRteKlgaNoZq7VuUgoGnF5xxtYJ-2FgiUmnnufUx-2B813GaPr1uP3IgSWScW8z-2BlBji10wK-2FvZOD9ePuAgH0vN19msEvO8bGCzCAuUNJXiHNTTy0E1oNW2LEVwmSQ1sJ0" class="btn btn-success">Register<span class="wb-invisible"> for "How to audit"</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="508-ada-testers" class="mrgn-tp-0">eAccessibility for Section 508 and ADA, and Trusted Testers</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>You will learn how to make your current sites more accessible by complying with current legislation, standards, and guidelines.</p>
+                <p>By addressing and understanding accessibility issues, Web developers can more effectively deliver their message to their whole audience, while complying with the legal and moral responsibilities, regardless of physical or mental impediment.</p>
+            </dd>
+            <dt>Level:</dt>
+            <dd>Beginner</dd>
+            <dt>Provider:</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>None</dd>
+            <dt>Duration:</dt>
+            <dd>Half-day course, one-day course, three-day course.</dd>
+            <dt>Delivery type:</dt>
+            <dd>online or onsite</dd>
+            <dt>Estimated cost:</dt>
+            <dd>CAD$330 (group discounts available)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-course-revised-section-508-ada/" class="btn btn-success">Register<span class="wb-inv"> for eAccessibility for Section 508 and ADA, and Trusted Testers</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="accessible-canada-act" class="mrgn-tp-0">Accessible Canada Act</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>Provide a basis for understanding existing policies. Explain the purpose of the ACL and identify principles relevant to web application issues.</p>
+            </dd>
+            <dt>Level:</dt>
+            <dd>N/A</dd>
+            <dt>Provider:</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/eng/">Justice Canada Website </a></dd>
+            <dt>Prerequisite:</dt>
+            <dd>None</dd>
+            <dt>Duration :</dt>
+            <dd>N/A</dd>
+            <dt>Delivery type:</dt>
+            <dd>Online reading</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language :</dt>
+            <dd>French or English</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/eng/acts/A-0.6/" class="btn btn-success">Read<span class="wb-inv"> Accessible Canada Act</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="accessibility-strategy" class="mrgn-tp-0">Accessibility Strategy for the Public Service of Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Learning objective:</dt>
+            <dd>
+                <p>Improve your understanding of the Government of Canada's desired state of technological accessibility for clients and employees. Explain what the Government of Canada is doing to improve accessibility using technology.</p>
+            </dd>
+            <dt>Level:</dt>
+            <dd>N/A</dd>
+            <dt>Provider :</dt>
+            <dd><a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Web Site  </a></dd>
+            <dt>Prerequisite :</dt>
+            <dd>None</dd>
+            <dt>Duration:</dt>
+            <dd>N/A</dd>
+            <dt>Delivery type:</dt>
+            <dd>Online reading</dd>
+            <dt>Estimated cost:</dt>
+            <dd>Free</dd>
+            <dt>Language :</dt>
+            <dd>French or English</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/accessibility-strategy-public-service-toc.html" class="btn btn-success">Read<span class="wb-inv"> Accessibility Strategy for the Public Service of Canada</span></a></p>
+    </div>
+</div>

--- a/src/en/curriculum/writers-editors-translators.html
+++ b/src/en/curriculum/writers-editors-translators.html
@@ -1,0 +1,280 @@
+---
+title: Writers, Editors and Translators
+layout: layouts/base.njk
+description: Accessibility courses for Writers, Editors and Translators
+---   
+            <div class="well">
+                <ul>
+                    <li><a href="#writing-a313">Fundamentals of Writing for the Web (A313)</a></li>
+                    <li><a href="#writing-proofreading">Writing (and proofreading) for the web with accessibility in mind</a></li>
+                    <li><a href="#wcag2-word">WCAG 2 for Word: accessible documents and templates for public servants</a></li>
+                    <li><a href="#PP-PDF">Creating accessible presentations: from PowerPoint to PDF</a></li>
+                    <li><a href="#spreadsheets">Accessible spreadsheets</a></li>
+                    <li><a href="#wcag2-office">WCAG 2 for Office: from Word and PowerPoint to PDF</a></li>
+                    <li><a href="#multimediaTeams">eAccessibility for Multimedia Teams</a></li>
+                    <li><a href="#writing-web">Writing for the Web with accessibility in mind</a></li>
+                    <li><a href="#accessible-canada-act">Accessible Canada Act</a></li>
+                    <li><a href="#accessibility-strategy">Accessibility Strategy for the Public Service of Canada</a></li>
+                </ul>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="writing-a313" class="mrgn-tp-0">Fundamentals of Writing for the Web (A313)</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>As more and more Canadians turn to the Internet for information and services, creating an effective web presence is vital for all government organizations. This course introduces new web writers to best practices for planning, writing and managing their web content. Participants will learn techniques for creating clear, readable content that best serves their audience's needs.</dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd>Canada School of Public Service</dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>7.5 hours</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>In class</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                    </dl>
+                    <p><a href="https://learn-apprendre.csps-efpc.gc.ca/application/en/content/fundamentals-writing-web-a313" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Fundamentals of Writing for the Web (A313)</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="writing-proofreading" class="mrgn-tp-0">Writing (and proofreading) for the web with accessibility in mind</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Become familiar with the best practices and prescribed rules, guidelines and standards of writing and creating content that includes everybody.</p>
+                            <p>Be confident that you know when you've reached the point where you can proudly proclaim that your content meets or exceeds the standards.</p>
+                            <p>At the end of this event, you will have these learning outcomes:</p>
+                            <ul>
+                                <li>know techniques you can apply right away to make your words, your graphics, and all your multimedia content more accessible.</li>
+                                <li>have a comprehensive understanding of W3C's WCAG 2.0, WCAG 2.1, PDF/UA, AODA, ADA, and other current accessibility standards and how to meet them.</li>
+                            </ul>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day, full day or Keynote presentation. We also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/writing-for-web-accessibility/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Writing (and proofreading) for the web with accessibility in mind</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="wcag2-word" class="mrgn-tp-0">WCAG 2 for Word: accessible documents and templates for public servants</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>We've worked with other accessibility experts, as well as Microsoft engineers, to put together this comprehensive and powerful course, where attendees walk away with immediately-applicable tips and techniques to make Word content accessible.</p>
+                            <p>Whether fixing existing .doc and .docx files or creating a system of Word templates where accessibility is baked in, we'll demystify how to make Word accessible.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Intermediate knowledge of Microsoft Word</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day, full day or Keynote presentation. We also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessible-word-for-public-servants/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for WCAG 2 for Word</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="PP-PDF" class="mrgn-tp-0">Creating accessible presentations: from PowerPoint to PDF</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>Upon completion, participants will be able to successfully create an accessible PowerPoint file (WCAG 2 Level AA compliant) using Microsoft PowerPoint.</dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Intermediate knowledge of Microsoft PowerPoint</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day, full day, or keynote presentation. We also provide this course customized on-site for your organization</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9xBCbQwEBAW6FGAHzfWlEIZwj4mt6OjvWsnr5RJ2jRZvDx4nVaoDEuHdtYnezHm8K_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTutENb3vuPnidclMF-2BrGRH42BcPmULKhMIGlPwsDb2y0WMJrpXv5qCRsE2DnKAda7HYIH-2BOBQUEHo2sreBfKYh9qpNvOShe5n28jBqMD2pu5Cp0mwNoeEYQMPU3zAAIuo9NrWc8MtS3KTA-2FIz-2FhPqY80Wuq4Cjf7-2BpGUDrbzKkbZ" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Creating accessible presentations: from PowerPoint to PDF</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="spreadsheets" class="mrgn-tp-0">Accessible spreadsheets</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Upon completion, participants will be able to successfully create an accessible spreadsheet file (WCAG 2 Level AA compliant) using Microsoft Excel and/or Google Sheets.</p>
+                            <p>At the end of this event, you will:</p>
+                            <ul>
+                                <li>know many techniques you can apply right away to make spreadsheet content more accessible.</li>
+                                <li>have a comprehensive understanding of W3C WCAG 2 and current government accessibility policies, and how to meet them.</li>
+                            </ul>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd></dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Intermediate knowledge of Microsoft Excel and/or Google Sheets</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day or full day, or Keynote presentation. wWe also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9xBCbQwEBAW6FGAHzfWlEIXe3F5KZJw3wnbQG4NWmdUcWXkjVRrsVAnJxH24RQFA7_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTjNJNBUanJk1Hlj2miLr95XYLnXl1uw4F6caaNacsp3UrnFStObGxARd3SE1-2F6LIk5GOkuSgDlAUfDwFWliyS-2F-2BCoixTAiU6CWTfn8CVYSGs7SL685CEKr-2FGLy8gCti-2FLFm2MydyciqNO684KxdB6wcpLq8v9CEXiBHV3OEIG3RU" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Accessible spreadsheets</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="wcag2-office" class="mrgn-tp-0">WCAG 2 for Office: from Word and PowerPoint to PDF</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>This course provides in-depth familiarity with W3C WCAG 2 (addressing both WCAG 2.0 and 2.1) and PDF/UA success criteria. These guidelines will help your Word, PowerPoint, and PDF documents be more effective resources for your entire audience. You'll also gain familiarity with the assistive technologies that help people with specific disabilities and difficulties.</p>
+                            <p>Our courses include a thorough review of all pertinent standards to comply with international and government federal or regional policies (such as the United States ADA and Revised Section 508, Canada's Standard on Web Accessibility, Ontario's AODA).</p>
+                            <p>This course incorporates adult learning principles and activities appropriate to a variety of learning styles, and qualifies for CEUs (certified by organizations such as PPAC).</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Intermediate</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Experience with Word and PowerPoint is required, experience with accessibility and WCAG 2.0 or 2.1 is recommended.</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day or full day. Also provide this course customized on-site for your organization.</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9NQl07KNJA-2FkjfgzQ2sXW1iC0P7QOw-2BSP2KhQifrj4zH3tnbh3JSkXTRgoTzJRdpcRp5I-2FfeZ-2F6AI51NYQ2kGJZ171ITNjQFKl8PcPrwwOwk-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTsjpmdWznFsGoa-2FbIWO2qP0bu8vGdKI0AP98BbKwvfgYg0I0hO-2Bpan2ADQbGj3iGu9er1CDLxewVtpWMXjGatG0VEEJL5yO5siv658ioyHJvzpaTzEvHgBzd7KAu17oEz8JgMH9gLi2ixtz5aGLBkkjbtl7m8xpzF7hHF6cKXnGO" class="btn btn-success">Register<span class="wb-inv">&nbsp;for WCAG 2 for Office: from Word and PowerPoint to PDF</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="multimediaTeams" class="mrgn-tp-0">eAccessibility for Multimedia Teams</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>This course will convince you why accessibility and standards are important for everybody: to broaden your audience, to comply with the law, to drive down costs, or simply to be socially responsible. He also provides in-depth familiarity with W3C WCAG 2 (addressing both WCAG 2.0 and 2.1) success criteria for multimedia.</p>
+                            <p>Our course material includes a thorough review of all pertinent standards to comply with international and government federal or regional policies (such as the United States' ADA and Section 508, the upcoming Accessible Canada Act, Ontario's AODA.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd></dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>Experience with digital video is required, experience with accessibility and WCAG 2.0 or 2.1 is recommended.</dd>
+                        <dt>Duration:</dt>
+                        <dd>Half-day or full day. Also provide this course customized on-site for your organization</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>online or onsite</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9NQl07KNJA-2FkjfgzQ2sXW1iC0P7QOw-2BSP2KhQifrj4zGJZjYnOMz4u-2BFyuW0gjcDhrrXSM5FG4S-2FS2W4GU0e0NQ-3D-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTnRlu5L0ZZWX-2Fcu6ekFVsJ1Bz2qHdTVuzWy3ktVBNgvjkH-2Fx5bLwDTx5BfZ-2Ftxae68sPsV4j5A8Ccn6VRV-2FKonL1bhp-2Bd6be83gzXaYo-2FcbWMCAsTnDb2jJWS0EeQLnPYLk4bnN9ctWCNBxTLqIBHpD18KRsA96c1G1RJVtrKFGs" class="btn btn-success">Register<span class="wb-inv">&nbsp;for eAccessibility for Multimedia Teams</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="writing-web" class="mrgn-tp-0">Writing for the Web with accessibility in mind</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>At the end of this event, you will have these learning outcomes:</p>
+                            <ul>
+                                <li>Know techniques you can apply right away to make your words, your graphics, and all your multimedia content more accessible.</li>
+                                <li>Have a comprehensive understanding of W3C's WCAG 2.0, WCAG 2.1, PDF/UA, AODA, ADA, and other current accessibility standards and how to meet them.</li>
+                                <li>Be able to make informed decisions as to what degree to comply with accessibility standards.</li>
+                            </ul>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>Beginner</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications</a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>One-day course, half-day course, or keynote presentation. We provide this topic customized on-site for your organization).</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>CAD$330 (group discounts available)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/writing-for-web-accessibility/" class="btn btn-success">Register<span class="wb-inv">&nbsp;for Writing for the Web with accessibility in mind</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessible-canada-act" class="mrgn-tp-0">Accessible Canada Act</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Provide a basis for understanding existing policies. Explain the purpose of the ACL and identify principles relevant to web application issues.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider:</dt>
+                        <dd><a href="https://laws-lois.justice.gc.ca/eng/">Justice Canada Website </a></dd>
+                        <dt>Prerequisite:</dt>
+                        <dd>None</dd>
+                        <dt>Duration :</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://laws-lois.justice.gc.ca/eng/acts/A-0.6/" class="btn btn-success">Register<span class="wb-inv"> for Accessible Canada Act</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="accessibility-strategy" class="mrgn-tp-0">Accessibility Strategy for the Public Service of Canada</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Learning objective:</dt>
+                        <dd>
+                            <p>Improve your understanding of the Government of Canada's desired state of technological accessibility for clients and employees. Explain what the Government of Canada is doing to improve accessibility using technology.</p>
+                        </dd>
+                        <dt>Level:</dt>
+                        <dd>N/A</dd>
+                        <dt>Provider :</dt>
+                        <dd><a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Web Site  </a></dd>
+                        <dt>Prerequisite :</dt>
+                        <dd>None</dd>
+                        <dt>Duration:</dt>
+                        <dd>N/A</dd>
+                        <dt>Delivery type:</dt>
+                        <dd>Online reading</dd>
+                        <dt>Estimated cost:</dt>
+                        <dd>Free</dd>
+                        <dt>Language :</dt>
+                        <dd>French or English</dd>
+                    </dl>
+                    <p><a href="https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/accessibility-strategy-public-service-toc.html" class="btn btn-success">Read<span class="wb-inv"> for Accessibility Strategy for the Public Service of Canada</span></a></p>
+                </div>
+            </div>
+		

--- a/src/fr/curriculum/a11ycheck-nonweb.html
+++ b/src/fr/curriculum/a11ycheck-nonweb.html
@@ -1,0 +1,96 @@
+---
+title: Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)
+layout: layouts/base.njk
+description: Ressources d'accessibilité pour le non Web ou les logiciels
+--- 
+<section>
+    <h2>1 &ndash; Éléments de clavier</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.2 &ndash; La tabulation est-elle conçue selon un ordre logique qui est de gauche à droite et de haut
+            en bas?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.3 &ndash; Les commandes peuvent-elles toutes être atteintes par le biais de la touche de tabulation ou
+            d’autres touches de navigation sans utiliser une souris (p. ex : F6 pour les volets de tâches)?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.4 &ndash; Y a-t-il un indicateur visuel et point d’insertion bien définis qui se déplacent à l’aide
+            des commandes de navigation du clavier standard?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.5 &ndash; Y a-t-il un indicateur de la navigation au clavier (« _ » – touche d’accès soulignée) pour
+            toutes les commandes de menu et de contrôle?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>1.6 &ndash; Existe-t-il un équivalent du menu pour toutes les fonctions présentes dans toutes les barres
+            d’outils et les barres de format?</li>
+    </ul>
+</section>
+<section>
+    <h2>2 &ndash; Éléments de couleurs</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>2.1 &ndash; Est-ce que la couleur dans l’application est utilisée seulement dans le but d’enrichir
+            l’image et non juste pour transmettre de l’information ou indiquer une action?</li>
+    </ul>
+</section>
+<section>
+    <h2>3 &ndash; Éléments cognitifs</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>3.1 &ndash; L’application évite-t-elle l’utilisation d’acronymes qui ne sont pas définis ailleurs?</li>
+    </ul>
+</section>
+<section>
+    <h2>4 &ndash; Éléments de commentaires et message d'erreures</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>4.1 &ndash; Les documents peuvent-ils être générés dans plus d’un format?</li>
+    </ul>
+</section>
+<section>
+    <h2>5 &ndash; Éléments de textes à l'écran / Screen Texts related items</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.1 &ndash; Est-ce que les fenêtres, les objets et les commandes ont tous un nom clairement identifié à
+            l’aide d’une étiquette ou d’un titre?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.2 &ndash; Les commandes de la barre d’outils sont-elles toutes dotées d’une aide contextuelle ou de
+            trucs et d’astuces des outils?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>5.3 &ndash; Chaque fenêtre a-t-elle un titre unique et significatif?</li>
+    </ul>
+</section>
+<section>
+    <h2>6 &ndash; Éléments de icones, images et curseur</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.1 &ndash; L’application utilise-t-elle les icônes standards du système d’exploitation pour les
+            fonctions courantes (p. ex. l’icône de la disquette pour sauvegarder)?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.2 &ndash; L’application utilise-t-elle les mêmes icônes tout au long de l’application pour les mêmes
+            fonctions?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.3 &ndash; L’application évite-t-elle d’utiliser des motifs de fond d’écran?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.4 &ndash; Quand on peut ajouter des images, l’application permet-elle d’inclure une description de
+            l’image?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>6.5 &ndash; L’application utilise-t-elle les curseurs de souris définies par le S/E?</li>
+    </ul>
+</section>
+<section>
+    <h2>7 &ndash; Éléments d'options d'accessbilité</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>7.1 &ndash; Est-ce que les fonctions d'accessibilité du système d'exploitation fonctionnent toujours
+            lorsque l'application est en cours d'exécution?</li>
+    </ul>
+</section>
+<section>
+    <h2>8 &ndash; Éléments de multimédia, sons et animation</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.1 &ndash; L’application est-elle munie d’une alternative textuelle ou visuelle relativement à
+            l’information disponible en format audio?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.2 &ndash; Le volume peut-il être modifié ou mis en sourdine?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.3 &ndash; L’application a-t-elle une description textuelle pour le format audio?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>8.4 &ndash; Est-ce que l’application permet de désactiver les animations?</li>
+    </ul>
+</section>
+<section>
+    <h2>9 &ndash; Éléments de documentation</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.1 &ndash; Les raccourcis de clavier pouvant être utilisés avec l’application sont-ils tous clairement
+            indiqués dans la documentation?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.2 &ndash; La documentation fournit-elle des instructions étape par étape précises et claires
+            relativement au clavier, et ce, pour toutes les fonctions du programme?</li>
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>9.3 &ndash; Les documents comprennent-ils du texte afin de décrire les images?</li>
+    </ul>
+</section>
+<section>
+    <h2>10 &ndash; Éléments de synchronisation</h2>
+    <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
+        <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>10.1 &ndash; L’application évite-t-elle l’utilisation de texte et d’objets clignotants ou d’autres
+            éléments semblables?</li>
+    </ul>
+</section>

--- a/src/fr/curriculum/desktop-application-developer.html
+++ b/src/fr/curriculum/desktop-application-developer.html
@@ -1,0 +1,253 @@
+---
+title: Développeurs d'applications bureautiques
+layout: layouts/base.njk
+description: Cours sur l'accessibilité pour les développeurs d'applications de bureau
+--- 
+<div class="well">
+    <ul>
+        <li><a href="#301-549-video">EN 301 549 s&eacute;rie de vid&eacute;os</a></li>
+        <li><a href="#favoriser-participation">Accessibilit&eacute; num&eacute;rique : Favoriser la participation &agrave; la soci&eacute;t&eacute; de l'information</a></li>
+        <li><a href="#materiel-pedagogique-accessible">Conception de mat&eacute;riel p&eacute;dagogique accessible <small>[variantes : g&eacute;n&eacute;ral, Adobe Captivate, Articulate Storyline, Blackboard]</small></a></li>
+        <li><a href="#t716-desktop">T716 : Accessibilit&eacute; des sites Web de Canada.ca</a></li>
+        <li><a href="#wcag-lecture">R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.1 (en anglais seulement) Activit&eacute; adapt&eacute;e au rythme de l'apprenant &ndash; lecture</a></li>
+        <li><a href="#themes-styles">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Th&egrave;mes et styles</a></li>
+        <li><a href="#wet-plugins">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Plug ins</a></li>
+        <li><a href="#loi-canadienne">Loi canadienne sur l’accessibilité</a></li>
+        <li><a href="#technologie-strategie">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</a></li>
+        <li><a href="#liste">Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="301-549-video" class="mrgn-tp-0">EN 301 549 s&eacute;rie de vid&eacute;os (lien externe) (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Description incluse dans la vid&eacute;o.</dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org">Vid&eacute;o YouTube</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>1,5 heure</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Vid&eacute;o</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Note :</dt>
+            <dd>Les vidéos YouTube sont accessibles hors réseau.</dd>
+        </dl>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="favoriser-participation" class="mrgn-tp-0">Accessibilit&eacute; num&eacute;rique : Favoriser la participation &agrave; la soci&eacute;t&eacute; de l'information (lien externe) (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Ce cours vous permettra de comprendre les obstacles que doivent surmonter les personnes ayant une incapacit&eacute; sensorielle, physique ou cognitive lorsqu'elles utilisent les technologies num&eacute;riques. Le cours expliquera de quelle mani&egrave;re la conception accessible et inclusive contribue &agrave; &eacute;liminer bon nombre de ces difficult&eacute;s.</dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.futurelearn.com/courses/digital-accessibility">Futurelearn (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>15 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Cours en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Note :</dt>
+            <dd>actuellement non disponible</dd>
+        </dl>
+        <p><a href="https://www.futurelearn.com/courses/digital-accessibility" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Accessibilit&eacute; num&eacute;rique : Favoriser la participation &agrave; la soci&eacute;t&eacute; de l'information</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="materiel-pedagogique-accessible" class="mrgn-tp-0">Conception de mat&eacute;riel p&eacute;dagogique accessible [variantes : g&eacute;n&eacute;ral, Adobe Captivate, Articulate Storyline, Blackboard] (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Peu importe l'outil que vous utilisez (Adobe Captivate, Articulate Storyline, Studio, Canvas, Lectora, ATutor ou le langage HTML5), nous vous expliquerons en d&eacute;tail la marche &agrave; suivre pour cr&eacute;er un contenu qui saura plaire &agrave; l'ensemble de votre public cible, tout en vous conformant &agrave; la r&eacute;glementation relative &agrave; l'accessibilit&eacute; pour les personnes ayant un handicap. Le cours portera &eacute;galement sur la norme SCORM sur l'accessibilit&eacute; et les syst&egrave;mes de gestion de l'apprentissage (comme Blackboard et D2L). Vous verrez &agrave; quel point il est possible de r&eacute;duire le total de co&ucirc;ts et les efforts d&eacute;ploy&eacute;s tout en produisant de meilleurs r&eacute;sultats d'apprentissage pour tous.</dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant, Concepteurs de mat&eacute;riel p&eacute;dagogique</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une journ&eacute;e, d'une demi-journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-for-instructional-design/" class="btn btn-success">Inscrivez-vous<span class="wb-inv"> pour Conception de mat&eacute;riel p&eacute;dagogique accessible</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="t716" class="mrgn-tp-0">T716 : Accessibilit&eacute; des sites Web de Canada.ca</h3>
+        <p><strong>Remarque</strong> : Les participants doivent avoir un compte pour avoir acc&egrave;s au cours.</p>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Ce cours présente les normes et lignes directrices à ce sujet. Il met l’accent sur les exigences, les rôles et les responsabilités en matière de conformité à ces normes. Les participants apprendront à évaluer les Règles pour l’accessibilité des contenus Web (WCAG) 2.1 et à les appliquer de façon uniforme dans les pages Web de Canada.ca.</dd>
+            <dt>Fournisseur :</dt>
+            <dd>École de la fonction publique du Canada</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Spécialiste en information technique Web</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>15 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Cours en salle de classe</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Anglais et Français</dd>
+        </dl>
+        <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour T716 : Accessibilit&eacute; des sites Web de Canada.ca</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="wcag-lecture" class="mrgn-tp-0">R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.1 (en anglais seulement) Activit&eacute; adapt&eacute;e au rythme de l'apprenant &ndash; lecture</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.1 pr&eacute;sentent un large &eacute;ventail de recommandations qui visent &agrave; rendre les contenus Web plus accessibles. Ces lignes directrices traitent de l'accessibilit&eacute; du contenu Web qui est affich&eacute; sur les ordinateurs de bureau, les ordinateurs portatifs, les tablettes et les appareils mobiles.</dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd>Consortium World Wide Web (W3C)</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Non indiqu&eacute;</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours adapt&eacute; au rythme de l'apprenant.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Activit&eacute; adapt&eacute;e au rythme de l'apprenant &ndash; lecture.</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="http://www.w3.org/TR/WCAG21/" class="btn btn-success">Lire<span class="wb-inv">&nbsp;R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.1</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="themes-styles" class="mrgn-tp-0">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Th&egrave;mes et styles</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Cette plateforme frontale <a href="https://wet-boew.github.io/wet-boew/docs/ref/accolades-fr.html#primes">prim&eacute;e</a> permet de cr&eacute;er des sites Web qui sont <a href="https://wet-boew.github.io/wet-boew/index-fr.html#accessibility">accessibles</a>, <a href="https://wet-boew.github.io/wet-boew/index-fr.html#usability">faciles d'emploi</a>, <a href="https://wet-boew.github.io/wet-boew/index-fr.html#interoperability">interop&eacute;rables</a>, <a href="https://wet-boew.github.io/wet-boew/index-fr.html#mobile-friendly-responsive-design">adapt&eacute;s aux appareils mobiles</a> et <a href="https://wet-boew.github.io/wet-boew/index-fr.html#multilingual">multilingues</a>.</dd>
+            <dt>Niveau :</dt>
+            <dd>Tout</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://wet-boew.github.io/wet-boew/index.html">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Projet &agrave; source ouverte collaboratif dirig&eacute; par le gouvernement du Canada.</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours adapt&eacute; au rythme de l'apprenant.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Activit&eacute; adapt&eacute;e au rythme de l'apprenant &ndash; lecture</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="https://wet-boew.github.io/wet-boew/index.html" class="btn btn-success">Lire<span class="wb-inv">&nbsp;Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Th&egrave;mes et styles</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="wet-plugins" class="mrgn-tp-0">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Plug ins</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Les plug ins de la Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web offrent divers types de fonctionnalit&eacute;s utiles pour les sites Web, en appelant la fonction dans l'attribut de classe d'une balise HTML.</dd>
+            <dt>Niveau :</dt>
+            <dd>Tout</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://wet-boew.github.io/wet-boew/index.html">Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Projet &agrave; source ouverte collaboratif dirig&eacute; par le gouvernement du Canada.</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours adapt&eacute; au rythme de l'apprenant.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Activit&eacute; adapt&eacute;e au rythme de l'apprenant &ndash; lecture.</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="https://wet-boew.github.io/wet-boew/index.html" class="btn btn-success">Lire<span class="wb-inv">&nbsp;Bo&icirc;te &agrave; outils de l'exp&eacute;rience Web &ndash; Plug ins</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="loi-canadienne" class="mrgn-tp-0">La loi canadienne sur l’accessibilité</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Fournir une base pour vous aider à comprendre les politiques existantes. Expliquer le but de la LCA et déterminer les principes pertinents pour les problèmes liés aux applications Web.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/fra/">Site Web de Justice Canada </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/fra/lois/A-0.6/" class="btn btn-success">Lire<span class="wb-inv"> La loi canadienne sur l’accessibilité</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="technologie-strategie" class="mrgn-tp-0">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Améliorer votre compréhension de l’état souhaité du gouvernement du Canada en matière d’accessibilité technologique pour les clients et les employés. Expliquer ce que fait le gouvernement du Canada pour améliorer l’accessibilité à l’aide de la technologie.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Site Web du Conseil du Trésor du Canada  </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/strategie-accessibilite-fonction-publique-tdm.html" class="btn btn-success">Lire<span class="wb-inv"> Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</span></a></p>
+    </div>
+</div>
+
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="liste" class="mrgn-tp-0">Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</h3>
+        <dl class="dl-horizontal">
+
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd>Site Web de Emploi et Développement Social du Canada  </dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Outil en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>N/A</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="../../fr/curriculum/a11ycheck-nonweb.html" class="btn btn-success">Lire<span class="wb-inv"> Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</span></a></p>
+    </div>
+</div>

--- a/src/fr/curriculum/desktop-application-tester.html
+++ b/src/fr/curriculum/desktop-application-tester.html
@@ -1,0 +1,136 @@
+---
+title: Testeurs d'applications bureautiques
+layout: layouts/base.njk
+description: Cours sur l'accessibilité pour les testeurs d'applications Web
+--- 
+<div class="well">
+    <ul>
+        <li><a href="#EN-301-549">Norme EN 301-549 Logiciel non Web (chapitre 11)</a></li>
+        <li><a href="#EN-301-549-video">EN 301 549 : S&eacute;rie de vid&eacute;os</a></li>
+        <li><a href="#loi-canadienne">Loi canadienne sur l’accessibilité</a></li>
+            <li><a href="#technologie-strategie">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</a></li>
+            <li><a href="#liste">Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="EN-301-549" class="mrgn-tp-0">Norme EN 301-549 Logiciel non Web (chapitre 11) (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Le document intitul&eacute; <em>Accessibility requirements suitable for public procurement of ICT products and services in Europe</em> (les exigences en mati&egrave;re d'accessibilit&eacute; qui conviennent &agrave; l'acquisition, par les organismes publics, de produits et services de TIC en Europe) &eacute;nonce les exigences en mati&egrave;re d'accessibilit&eacute; fonctionnelle qui s'appliquent aux produits et services li&eacute;s &agrave; la technologie de l'information et de la communication (TIC). Ce document d&eacute;crit les proc&eacute;dures d'essai et les m&eacute;thodes d'&eacute;valuation qui s'appliquent &agrave; chaque exigence en mati&egrave;re d'accessibilit&eacute;. Les exigences se pr&ecirc;tent au contexte relatif aux march&eacute;s publics en Europe.</dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="http://mandate376.standards.eu/">Trousse d'outils relative &agrave; l'approvisionnement en mati&egrave;re de produits et de services TIC accessibles (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Non indiqu&eacute;</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours adapt&eacute; au rythme de l'apprenant.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="http://mandate376.standards.eu/standard/technical-requirements#11" class="btn btn-success">Lire<span class="wb-inv">&nbsp;Norme EN 301-549 Logiciel non Web (chapitre 11)</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="EN-301-549-video" class="mrgn-tp-0">EN 301 549 : S&eacute;rie de vid&eacute;os (lien externe) (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Comprendre la norme d’accessibilité EN 301 549 qui couvre les applications de bureau (logiciels), et la documentation et les services de soutien.  Expliquer les exigences d’accessibilité fonctionnelles applicables aux applications de bureau, décrire les procédures de mise à l’essai et évaluer la méthode pour chaque exigence d’accessibilité.</dd>
+            <dt>Niveau :</dt>
+            <dd>Avancé</dd>
+            <dt>Fournisseur :</dt>
+            <dd>YouTube</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>1 heure</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Visionnement en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Note:</dt> 
+            <dd>Les vidéos YouTube sont accessibles hors réseau.</dd>
+        </dl>
+        <p><a href="https://www.youtube.com/channel/UCdW_0pPNiiPLaLM90_20org/videos" class="btn btn-success">Regarder<span class="wb-inv">&nbsp;EN 301 549 : S&eacute;rie de vid&eacute;os (lien externe) (en anglais seulement)</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="loi-canadienne" class="mrgn-tp-0">La loi canadienne sur l’accessibilité</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Fournir une base pour vous aider à comprendre les politiques existantes. Expliquer le but de la LCA et déterminer les principes pertinents pour les problèmes liés aux applications Web.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/fra/">Site Web de Justice Canada </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/fra/lois/A-0.6/" class="btn btn-success">Lire<span class="wb-inv"> La loi canadienne sur l’accessibilité</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="technologie-strategie" class="mrgn-tp-0">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Améliorer votre compréhension de l’état souhaité du gouvernement du Canada en matière d’accessibilité technologique pour les clients et les employés. Expliquer ce que fait le gouvernement du Canada pour améliorer l’accessibilité à l’aide de la technologie.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Site Web du Conseil du Trésor du Canada  </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/strategie-accessibilite-fonction-publique-tdm.html" class="btn btn-success">Lire<span class="wb-inv"> Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</span></a></p>
+    </div>
+</div>
+
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="liste" class="mrgn-tp-0">Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</h3>
+        <dl class="dl-horizontal">
+
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd>Site Web de Emploi et Développement Social du Canada  </dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Outil en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>N/A</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="../../fr/curriculum/a11ycheck-nonweb.html" class="btn btn-success">Lire<span class="wb-inv"> Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</span></a></p>
+    </div>
+</div>

--- a/src/fr/curriculum/index.html
+++ b/src/fr/curriculum/index.html
@@ -1,0 +1,45 @@
+---
+title: Programme de formation sur l'accessibilité
+layout: layouts/base.njk
+description: Le programme de formation sur l'accessibilité est une liste de cours qui permettent d'acquérir des connaissances en matière d'accessibilité afin de mieux servir les clients internes et externes.
+---
+	<!-- DataAjaxFragmentStart -->
+	<div class="alert alert-info">
+			<p>Les liens qui ne fonctionnent qu'au sein du réseau d'EDSC ou derrière le pare-feu du gouvernement du Canada sont marqués avec <i class="fas fa-external-link-square-alt" aria-hidden="true"> Icône</i><span class="wb-inv">Lien interne</span></p>
+		</div>
+	<!-- DataAjaxFragmentEnd -->
+</div>
+<h2>Intention et vision du programme de formation sur l'accessibilit&eacute;</h2>
+<p>La nouvelle <a href="https://www.parl.ca/DocumentViewer/fr/42-1/projet-loi/C-81/sanction-royal"><em>Loi canadienne sur l'accessibilit&eacute;</em></a> exigera que les employ&eacute;s de la Direction g&eacute;n&eacute;rale de l'innovation, de l'information et de la technologie (DGIIT) prennent connaissance des obligations qui leur incombent afin de garantir l'accessibilit&eacute; de leur environnement de travail. La liste des cours permettra aux employ&eacute;s d'approfondir leurs connaissances en mati&egrave;re d'accessibilit&eacute; et de mieux r&eacute;pondre aux besoins de leurs clients internes et externes. De plus, cette liste donnera &agrave; des publics cibles diversifi&eacute;s (tels que les gestionnaires de projet, ainsi que les d&eacute;veloppeurs, les programmeurs et les techniciens de la DGIIT) les outils n&eacute;cessaires pour fournir de fa&ccedil;on proactive des services, des logiciels et des programmes accessibles, qui r&eacute;pondent le mieux aux besoins de nos coll&egrave;gues qui utilisent la technologie informatique adapt&eacute;e (TIA).</p>
+<h3>Mandat de la DGIIT :</h3>
+<ul>
+	<li>Fournir des services modernes, s&eacute;curis&eacute;s, efficaces et efficients en mati&egrave;re d'information et de technologie qui apportent la plus grandes valeur aux besoins de nos clients.</li>
+	<li>&Eacute;tablir des liens s&eacute;curitaires entre l'information et la technologie pour nos clients, les partenariats et les citoyens.</li>
+</ul>
+<h3>Mandat en mati&egrave;re d'accessibilit&eacute; de la technologie de l'information :</h3>
+<ul>
+	<li>&Ecirc;tre un chef de file en mati&egrave;re d'accessibilit&eacute;, promouvoir et favoriser un milieu de travail qui n'exclut personne et permettre &eacute;galement la prestation de services aux Canadiens en fournissant des technologies d'adaptation et des solutions accessibles.</li>
+</ul>
+<h3>Apprenants cibles</h3>
+<ul>
+	<li>L'accessibilit&eacute; est d&eacute;sormais l'une des grandes priorit&eacute;s d'Emploi et D&eacute;veloppement social Canada. La formation s'adresse par cons&eacute;quent aux publics cibles suivants :
+		<ul>
+			<li>Tous les d&eacute;veloppeurs et les testeurs d'applications de niveau CS01 et CS02 ;</li>
+			<li>Les chefs d'&eacute;quipe, les chefs de projet et les sp&eacute;cialistes de la TI de niveau CS03 qui sont responsables du d&eacute;veloppement d'applications ;</li>
+			<li>Le personnel de direction d'EDSC ;</li>
+			<li>Les r&eacute;dacteurs, les r&eacute;viseurs et les traducteurs ;</li>
+			<li>Tous les autres employ&eacute;s d'EDSC.</li>
+		</ul>
+	</li>
+</ul>
+<p>Le temps total consacr&eacute; &agrave; la formation d&eacute;pend de chaque employ&eacute; et de ses connaissances actuelles en mati&egrave;re d'accessibilit&eacute;.</p>
+<p>Certains des cours d&eacute;crits ci-dessous sont offerts par des fournisseurs externes, uniquement en anglais. D'autres cours sont offerts par le Coll&egrave;ge@EDSC et l'&Eacute;cole de la fonction publique du Canada. Puisqu'EDSC n'est pas affili&eacute; &agrave; ces cours et ne participe pas &agrave; la mise &agrave; jour de ces sites Web, le minist&egrave;re ne peut &ecirc;tre tenu responsable de leur contenu. Ces sites Web constituent une ressource et sont &agrave; utiliser avec pr&eacute;caution.</p>
+<ul class="lst-spcd">
+	<li><a href="http://iservice.prv/fra/college/competence-interculturelle/accessibilite.shtml">Formation pour tous <i class="fas fa-external-link-square-alt" aria-hidden="true"></i><span class="wb-inv">Lien interne</span></a></li>		
+		<li><a href="./web-application-developer.html">Développeurs d'application web</a></li>
+		<li><a href="./web-application-tester.html">Testeurs d'applications web</a></li>
+		<li><a href="./desktop-application-developer.html">Développeurs d'applications bureautiques</a></li>
+		<li><a href="./desktop-application-tester.html">Testeurs d'applications bureautiques</a></li>
+		<li><a href="./writers-editors-translators.html">Rédacteurs, réviseurs et traducteurs</a></li>
+	</ul>
+	

--- a/src/fr/curriculum/web-application-developer.html
+++ b/src/fr/curriculum/web-application-developer.html
@@ -1,0 +1,317 @@
+---
+title: Développeurs d'application web
+layout: layouts/base.njk
+description: Cours sur l'accessibilité pour les développeurs d'applications Web
+---
+<div class="well">
+    <ul>
+        <li><a href="#t716">T716 : Accessibilit&eacute; des sites Web de Canada.ca</a></li>
+        <li><a href="#accessibilite-web-developpeurs">Accessibilit&eacute; des sites Web pour les d&eacute;veloppeurs</a></li>
+        <li><a href="#trousse-programme">Trousse du programme de formation sur l'accessibilit&eacute; du Web</a></li>
+        <li><a href="#quoi-wcag">WCAG 2.1 : Quoi de neuf?</a></li>
+        <li><a href="#analyse-approfondie-WCAG">Analyse approfondie des WCAG pour les &eacute;quipes Web</a></li>
+        <li><a href="#developpement-accessible">D&eacute;veloppement accessible pour les applications et les sites mobiles</a></li>
+        <li><a href="#formulaires-accessibles">Cr&eacute;er des formulaires accessibles : AcroForms et Adobe LiveCycle Designer</a></li>
+        <li><a href="#InDesign">Cr&eacute;er des documents PDF accessibles avec Adobe InDesign</a></li>
+        <li><a href="#audit">L'audit professionnel de l'accessibilité du Web simplifié </a></li>
+        <li><a href="#loi-canadienne">Loi canadienne sur l’accessibilité</a></li>
+        <li><a href="#technologie-strategie">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="t716" class="mrgn-tp-0">T716 : Accessibilit&eacute; des sites Web de Canada.ca</h3>
+        <p><strong>Remarque</strong> : Les participants doivent avoir un compte pour avoir acc&egrave;s au cours.</p>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Ce cours présente les normes et lignes directrices à ce sujet. Il met l’accent sur les exigences, les rôles et les responsabilités en matière de conformité à ces normes. Les participants apprendront à évaluer les Règles pour l’accessibilité des contenus Web (WCAG) 2.1 et à les appliquer de façon uniforme dans les pages Web de Canada.ca.</dd>
+            <dt>Fournisseur :</dt>
+            <dd>École de la fonction publique du Canada</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Spécialiste en information technique Web</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>15 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Cours en salle de classe</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Anglais et Français</dd>
+        </dl>
+        <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour T716 : Accessibilit&eacute; des sites Web de Canada.ca</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="accessibilite-web-developpeurs" class="mrgn-tp-0">Accessibilit&eacute; des sites Web pour les d&eacute;veloppeurs (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Avec l'introduction de la sp&eacute;cification WAI-ARIA (Initiative pour l'accessibilit&eacute; du Web &ndash; Applications Internet riches et accessibles), les d&eacute;veloppeurs peuvent d&eacute;velopper des &eacute;l&eacute;ments interactifs pour le Web en faisant preuve de bien plus de cr&eacute;ativit&eacute; qu'auparavant. Utilis&eacute;e avec le langage JavaScript accessible, cette sp&eacute;cification propose des possibilit&eacute;s infinies d'interactions sur le Web, qui peuvent &eacute;galement profiter aux personnes qui recourent &agrave; la technologie d'assistance.</dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://de.ryerson.ca/wa/">Universit&eacute; Ryerson</a> (en anglais seulement)</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>
+                <ul>
+                    <li>Capacit&eacute; de d&eacute;velopper des applications en utilisant JavaScript, HTML5 et CSS</li>
+                    <li>Un compte GitHub</li>
+                    <li>Un environnement de d&eacute;veloppement local</li>
+                </ul>
+            </dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>37,5 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Cours en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="https://de.ryerson.ca/wa/advanced/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Accessibilit&eacute; des sites Web pour les d&eacute;veloppeurs</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="trousse-programme" class="mrgn-tp-0">Trousse du programme de formation sur l'accessibilit&eacute; du Web (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Vous en apprendrez davantage sur les principes fondamentaux de l’accessibilité, des normes et des techniques de mise à l’essai de la TI. Vous serez en mesure de fournir des conseils et une orientation sur l’élaboration et la mise à l’essai de l’accessibilité dans les applications Web accessibles.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Avanc&eacute;</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.deque.com/">Université Deque (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>37,5 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Cours en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>
+                <p>$150 US ou gratuit pour ceux qui ont un handicap et reçoivent la <a href="https://dequeuniversity.com/scholarships">bourse Deque</a> (Anglais seulement)</p>
+            </dd>
+            <dt>Langue :</dt>
+            <dd>Anglais</dd>
+        </dl>
+        <p><a href="https://dequeuniversity.com/curriculum/packages/web" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Trousse du programme de formation sur l'accessibilit&eacute; du Web</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="quoi-wcag" class="mrgn-tp-0">WCAG 2.1 : Quoi de neuf? (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <ul>
+                    <li>Conna&icirc;tre des techniques &agrave; mettre en application imm&eacute;diatement.</li>
+                    <li>Conna&icirc;tre en profondeur les WCAG 2.1 du W3C et les lignes directrices gouvernementales en mati&egrave;re d'accessibilit&eacute; s'y rapportant.</li>
+                    <li>Parvenir &agrave; prendre des d&eacute;cisions &eacute;clair&eacute;es quant au niveau de conformit&eacute; aux normes d'accessibilit&eacute;.</li>
+                    <li>Mieux comprendre l'exp&eacute;rience v&eacute;cue par les personnes ayant un handicap au moyen de l'apprentissage en ligne, d'expos&eacute;s et des logiciels auteurs</li>
+                </ul>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Connaissance des R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 (exp&eacute;rience en programmation non requise)</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une journ&eacute;e, d'une demi-journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd> CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/whats-new-in-wcag-2-1/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour WCAG 2.1 : Quoi de neuf?</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="analyse-approfondie-WCAG" class="mrgn-tp-0">Analyse approfondie des WCAG pour les &eacute;quipes Web (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Le cours a pour but de pr&eacute;senter aux participants des techniques qu'ils pourront imm&eacute;diatement mettre en application pour la r&eacute;daction, la conception, la production et la mise &agrave; l'essai des crit&egrave;res pertinents d&eacute;finis par les WCAG.</p>
+                <p>Ce cours tient compte des principes d'apprentissage des adultes, propose des activit&eacute;s adapt&eacute;es &agrave; divers styles d'apprentissage, et remplit les conditions n&eacute;cessaires pour l'obtention de cr&eacute;dits d'&eacute;ducation permanente (certifi&eacute;s par des organisations comme le PPAC).</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Avancé</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Exp&eacute;rience des langages HTML, CSS et JavaScript/jQuery est n&eacute;cessaire. il est recommand&eacute; de conna&icirc;tre la question de l'accessibilit&eacute;, notamment les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 ou 2.1.</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Un ou deux jours. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9DROsfSey1r-2FtJ718kbAvXIrEjHcSvXH67OamqnUutLzxl9qa4Pmv6EQWT6B0PNV-2B_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTt-2FodR-2Fhd7sYvnASOtAn4uFfvIND6qR5MkV-2FbClKaW-2Bnlc-2BL0hre-2FbOuMCVt5ql03kXJBvFEpKb2S-2BxwGHKOmsgbivypVWvtzVx2Bzp-2FOCSfPD8h7Oluqr-2B2bZD6gJmmwqwyhG8dLp-2B7wg1hqWHkOk1wYLv4hWxjUotBW4g6KL6M" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Analyse approfondie des WCAG pour les &eacute;quipes Web</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="developpement-accessible" class="mrgn-tp-0">D&eacute;veloppement accessible pour les applications et les sites mobiles (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>&Agrave; la fin du cours, les participants :</p>
+                <ul>
+                    <li>Conna&icirc;tront en profondeur les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 du W3C, ainsi que les politiques gouvernementales actuelles en mati&egrave;re d'accessibilit&eacute; et sauront s'y conformer.</li>
+                    <li>Seront en mesure de prendre des d&eacute;cisions &eacute;clair&eacute;es quant au contenu &agrave; int&eacute;grer aux sites mobiles.</li>
+                    <li>Seront en mesure de prendre des d&eacute;cisions &eacute;clair&eacute;es lorsqu'ils h&eacute;sitent entre le d&eacute;veloppement d'une application native ou multiplateforme.</li>
+                </ul>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une journ&eacute;e, d'une demi-journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd> CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-for-mobile-tablets-and-touch/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour D&eacute;veloppement accessible pour les applications et les sites mobiles</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="formulaires-accessibles" class="mrgn-tp-0">Cr&eacute;er des formulaires accessibles : AcroForms et Adobe LiveCycle Designer (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>En plus de pr&eacute;senter autant des techniques fondamentales (structures appropri&eacute;es pour les balises et les codes) que des techniques avanc&eacute;es (solutions programmatiques aux probl&egrave;mes d'accessibilit&eacute;), le cours fournit aux concepteurs et aux d&eacute;veloppeurs les outils dont ils ont besoin pour se conformer aux WCAG et assurer l'accessibilit&eacute; fonctionnelle de leurs formulaires PDF cr&eacute;&eacute;s &agrave; l'aide de LiveCycle Designer (XFA) et d'AcroForms.</p>
+                <p>Le cours a pour but de pr&eacute;senter aux participants des techniques qu'ils pourront imm&eacute;diatement mettre en application pour la r&eacute;daction, la conception, la production et la mise &agrave; l'essai des crit&egrave;res pertinents d&eacute;finis par les WCAG.</p>
+                <p>Ce cours tient compte des principes d'apprentissage des adultes, propose des activit&eacute;s adapt&eacute;es &agrave; divers styles d'apprentissage, et remplit les conditions n&eacute;cessaires pour l'obtention de cr&eacute;dits d'&eacute;ducation permanente (certifi&eacute;s par des organisations comme le PPAC).</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>
+                <p>Exp&eacute;rience de l'utilisation des formulaires cr&eacute;&eacute;s &agrave; l'aide d'Acrobat AcroForms et/ou de LiveCycle Designer (XFA).</p>
+                <p>Il est recommand&eacute; de conna&icirc;tre les enjeux li&eacute;s &agrave; l'accessibilit&eacute;, notamment les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 ou 2.1.</p>
+            </dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Un ou deux jours</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd> CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO98YowxLnjwsusP-2FRIJXFBVIAGd-2FwVi-2FpND1mWxUI2it4OY03nILGotvtSz2cGMsdh_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTsn3L0F44Yp34BPoB4S0wrdK7X4bUXc6wHhfrESHWknQqfJrFMR6wGeh-2Fz6fKUmwxuTOtHzqGaMLMZB9svKpAOzq1s9UnG2-2Bshd4Rhg0SPLPJdOCnGO1m0QU4M0X2CJDS7awY51i20yW85NmXSsLL84rZDQ0qwwslUoyf6yswP2k" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Cr&eacute;er des formulaires accessibles : AcroForms et Adobe LiveCycle Designer</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="InDesign" class="mrgn-tp-0">Cr&eacute;er des documents PDF accessibles avec Adobe InDesign (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>&Agrave; la fin du cours, les participants seront en mesure de cr&eacute;er des documents PDF accessibles (conformes aux WCAG et &agrave; la norme PDF/UA) &agrave; l'aide d'Adobe InDesign et d'Adobe Acrobat Pro.</dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>
+                <ul>
+                    <li>Connaissances pr&eacute;alables recommand&eacute;es.</li>
+                    <li>Connaissance des R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.</li>
+                    <li>Connaissance d'Adobe InDesign.</li>
+                    <li>Connaissance d'Adobe Acrobat Pro.</li>
+                </ul>
+            </dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Un jour (5,5 heures d'enseignement)</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd></dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessible-indesign-course/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Cr&eacute;er des documents PDF accessibles avec Adobe InDesign</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="audit" class="mrgn-tp-0">L'audit professionnel de l'accessibilité du Web simplifié </h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>Vous serez en mesure de fournir des conseils et une orientation sur la vérification de l’observation en matière d’accessibilité des applications Web.</dd>
+            <dt>Niveau :</dt>
+            <dd>Avancé</dd>
+            <dt>Fournisseur :</dt>
+            <dd>Université Ryerson</dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun
+            </dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Environ 37,5 heures (à son propre rythme)</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne (livre à télécharger)</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Anglais</dd>
+        </dl>
+        <p><a href="https://pressbooks.library.ryerson.ca/pwaa/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Cr&eacute;er des documents PDF accessibles avec Adobe InDesign</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="loi-canadienne" class="mrgn-tp-0">La loi canadienne sur l’accessibilité</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Fournir une base pour vous aider à comprendre les politiques existantes. Expliquer le but de la LCA et déterminer les principes pertinents pour les problèmes liés aux applications Web.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/fra/">Site Web de Justice Canada </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/fra/lois/A-0.6/" class="btn btn-success">Lire<span class="wb-inv"> La loi canadienne sur l’accessibilité</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="technologie-strategie" class="mrgn-tp-0">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Améliorer votre compréhension de l’état souhaité du gouvernement du Canada en matière d’accessibilité technologique pour les clients et les employés. Expliquer ce que fait le gouvernement du Canada pour améliorer l’accessibilité à l’aide de la technologie.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Site Web du Conseil du Trésor du Canada  </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/strategie-accessibilite-fonction-publique-tdm.html" class="btn btn-success">Lire<span class="wb-inv"> Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</span></a></p>
+    </div>
+</div>

--- a/src/fr/curriculum/web-application-tester.html
+++ b/src/fr/curriculum/web-application-tester.html
@@ -1,0 +1,174 @@
+---
+title: Testeurs d'applications web
+layout: layouts/base.njk
+description: Cours sur l'accessibilité pour les testeurs d'applications Web
+--- 
+            <div class="well">
+                <ul>
+                    <li><a href="#t716">T716 : Accessibilit&eacute; des sites Web de Canada.ca</a></li>
+                    <li><a href="#301-549">Norme EN 301-549 Logiciel non Web (chapitre 11)</a></li>
+                    <li><a href="#astuces-verification">Astuces pour la v&eacute;rification : assurance de la qualit&eacute; accessible pour les sites, les applications et les documents</a></li>
+                    <li><a href="#508-ada-testers">Accessibilit&eacute; &eacute;lectronique pour l'article 508, la loi en faveur des Am&eacute;ricains ayant un handicap et les testeurs de confiance</a></li>
+                    <li><a href="#loi-canadienne">Loi canadienne sur l’accessibilité</a></li>
+                    <li><a href="#technologie-strategie">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</a></li>
+                </ul>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="t716" class="mrgn-tp-0">T716 : Accessibilit&eacute; des sites Web de Canada.ca</h3>
+                    <p><strong>Remarque</strong> : Les participants doivent avoir un compte pour avoir acc&egrave;s au cours.</p>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>Ce cours présente les normes et lignes directrices à ce sujet. Il met l’accent sur les exigences, les rôles et les responsabilités en matière de conformité à ces normes. Les participants apprendront à évaluer les Règles pour l’accessibilité des contenus Web (WCAG) 2.1 et à les appliquer de façon uniforme dans les pages Web de Canada.ca.</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd>École de la fonction publique du Canada</dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Spécialiste en information technique Web</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>15 heures</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>Cours en salle de classe</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>Gratuit</dd>
+                        <dt>Langue :</dt>
+                        <dd>Anglais et Français</dd>
+                    </dl>
+                    <p><a href="https://learn-apprendre.csps-efpc.gc.ca/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour T716 : Accessibilit&eacute; des sites Web de Canada.ca</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="301-549" class="mrgn-tp-0">Norme EN 301-549 Logiciel non Web (chapitre 11) (en anglais seulement)</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>Le document intitul&eacute; Accessibility requirements suitable for public procurement of ICT products and services in Europe (les exigences en mati&egrave;re d'accessibilit&eacute; qui conviennent &agrave; l'acquisition, par les organismes publics, de produits et de services de TIC en Europe) &eacute;nonce les exigences en mati&egrave;re d'accessibilit&eacute; fonctionnelle qui s'appliquent aux produits et services li&eacute;s &agrave; la technologie de l'information et de la communication (TIC). Ce document d&eacute;crit les proc&eacute;dures d'essai et les m&eacute;thodes d'&eacute;valuation qui s'appliquent &agrave; chaque exigence en mati&egrave;re d'accessibilit&eacute;. Les exigences se pr&ecirc;tent au contexte relatif aux march&eacute;s publics en Europe.</dd>
+                        <dt>Niveau :</dt>
+                        <dd>D&eacute;butant</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd><a href="http://mandate376.standards.eu/">Trousse d'outils relative &agrave; l'acquisition de produits et de services TIC accessibles</a> (en anglais seulement)</dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Non indiqu&eacute;</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>Cours adapt&eacute; au rythme de l'apprenant</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>Lecture</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>Gratuit</dd>
+                        <dt>Note :</dt>
+                        <dd>Les vidéos YouTube sont accessibles hors réseau.</dd>
+                    </dl>
+                    <p><a href="http://mandate376.standards.eu/standard/technical-requirements#11" class="btn btn-success">Lire<span class="wb-inv">&nbsp; Norme EN 301-549 Logiciel non Web (chapitre 11)</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="astuces-verification" class="mrgn-tp-0">Astuces pour la v&eacute;rification : assurance de la qualit&eacute; accessible pour les sites, les applications et les documents (en anglais seulement)</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>
+                            <p>Lignes directrices, principes et techniques n&eacute;cessaires pour satisfaire aux crit&egrave;res de succ&egrave;s (y compris les WCAG 2) (le cours porte sur les WCAG 2.0 et 2.1), WAI-ARIA (Initiative pour l'accessibilit&eacute; du Web &ndash; Applications Internet riches et accessibles), concepts de base, limites des lignes directrices, principes et techniques sp&eacute;cifiques, diff&eacute;rences entre les &eacute;l&eacute;ments normatifs et non normatifs ; les &eacute;l&eacute;ments figurant dans les diff&eacute;rents niveaux (A, AA, AAA).</p>
+                            <ul>
+                                <li>Assurance de la qualit&eacute; en mati&egrave;re d'accessibilit&eacute;.</li>
+                                <li>Technologies compatibles avec l'accessibilit&eacute;.</li>
+                                <li>Contr&ocirc;les normalis&eacute;s versus contr&ocirc;les personnalis&eacute;s.</li>
+                                <li>Strat&eacute;gies utilis&eacute;es par les personnes ayant un handicap qui utilisent les solutions Web.</li>
+                                <li>Probl&egrave;mes d'interop&eacute;rabilit&eacute; et de compatibilit&eacute;.</li>
+                                <li>Mise &agrave; l'essai avec les technologies d'assistance.</li>
+                                <li>Mise &agrave; l'essai pour &eacute;valuer l'incidence sur les utilisateurs finaux.</li>
+                                <li>Outils de mise &agrave; l'essai pour le Web (outils automatis&eacute;s et manuels).</li>
+                                <li>Niveau de gravit&eacute; et ordre de priorit&eacute; des probl&egrave;mes.</li>
+                            </ul>
+                        </dd>
+                        <dt>Niveau :</dt>
+                        <dd>Interm&eacute;diaire</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Exp&eacute;rience des langages HTML, CSS et JavaScript/jQuery. Il est recommand&eacute; de conna&icirc;tre la question de l'accessibilit&eacute;, notamment les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 ou 2.1.</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>Demi-journ&eacute;e ou journ&eacute;e compl&egrave;te. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>En ligne ou sur place</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>CAD330$ (rabais de groupe disponible)</dd>
+                    </dl>
+                    <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9DJWk5al2cBTBls5C7KCtdS2TWLcMuLKWSU3fnqFeXcw-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTu8opZhDf9tpc-2FyXZ8URStdJ2bfsUQTYZT-2B2D9Dlq25G9ljRteKlgaNoZq7VuUgoGnF5xxtYJ-2FgiUmnnufUx-2B813GaPr1uP3IgSWScW8z-2BlBji10wK-2FvZOD9ePuAgH0vN19msEvO8bGCzCAuUNJXiHNTTy0E1oNW2LEVwmSQ1sJ0" class="btn btn-success">Inscrivez-vous<span class="wb-invisible"> for "How to audit"</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="508-ada-testers" class="mrgn-tp-0">Accessibilit&eacute; &eacute;lectronique pour l'article 508, la loi en faveur des Am&eacute;ricains ayant un handicap et les testeurs de confiance (en anglais seulement)</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>
+                            <p>Les participants apprendront &agrave; am&eacute;liorer l'accessibilit&eacute; de leurs sites, tout en se conformant aux lois, aux normes et aux lignes directrices en vigueur.</p>
+                            <p>En abordant et en comprenant les probl&egrave;mes d'accessibilit&eacute;, les d&eacute;veloppeurs Web parviennent &agrave; transmettre plus efficacement leur message &agrave; l'ensemble de leur public cible, tout en respectant leurs responsabilit&eacute;s juridiques et morales, quelle que soit l'incapacit&eacute; physique ou mentale.</p>
+                        </dd>
+                        <dt>Niveau :</dt>
+                        <dd>D&eacute;butant</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Aucun</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>Cours d'une demi-journ&eacute;e, d'une journ&eacute;e ou de trois jours.</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>En ligne ou sur place</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>CAD330$ (rabais de groupe disponible)</dd>
+                    </dl>
+                    <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessibility-course-revised-section-508-ada/" class="btn btn-success">Inscrivez-vous<span class="wb-inv"> pour Accessibilit&eacute; &eacute;lectronique pour l'article 508, la loi en faveur des Am&eacute;ricains ayant un handicap et les testeurs de confiance</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="loi-canadienne" class="mrgn-tp-0">La loi canadienne sur l’accessibilité</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>
+                            <p>Fournir une base pour vous aider à comprendre les politiques existantes. Expliquer le but de la LCA et déterminer les principes pertinents pour les problèmes liés aux applications Web.</p>
+                        </dd>
+                        <dt>Niveau :</dt>
+                        <dd>N/A</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd><a href="https://laws-lois.justice.gc.ca/fra/">Site Web de Justice Canada </a></dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Aucun</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>N/A</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>Lecture en ligne</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>Gratuit</dd>
+                        <dt>Langue :</dt>
+                        <dd>Français ou Anglais</dd>
+                    </dl>
+                    <p><a href="https://laws-lois.justice.gc.ca/fra/lois/A-0.6/" class="btn btn-success">Lire<span class="wb-inv"> La loi canadienne sur l’accessibilité</span></a></p>
+                </div>
+            </div>
+            <div class="panel panel-primary">
+                <div class="panel-body">
+                    <h3 id="technologie-strategie" class="mrgn-tp-0">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</h3>
+                    <dl class="dl-horizontal">
+                        <dt>Objectif d&rsquo;apprentissage :</dt>
+                        <dd>
+                            <p>Améliorer votre compréhension de l’état souhaité du gouvernement du Canada en matière d’accessibilité technologique pour les clients et les employés. Expliquer ce que fait le gouvernement du Canada pour améliorer l’accessibilité à l’aide de la technologie.</p>
+                        </dd>
+                        <dt>Niveau :</dt>
+                        <dd>N/A</dd>
+                        <dt>Fournisseur :</dt>
+                        <dd><a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Site Web du Conseil du Trésor du Canada  </a></dd>
+                        <dt>Pr&eacute;alables :</dt>
+                        <dd>Aucun</dd>
+                        <dt>Dur&eacute;e :</dt>
+                        <dd>N/A</dd>
+                        <dt>Mode de prestation :</dt>
+                        <dd>Lecture en ligne</dd>
+                        <dt>Estimation du co&ucirc;t :</dt>
+                        <dd>Gratuit</dd>
+                        <dt>Langue :</dt>
+                        <dd>Français ou Anglais</dd>
+                    </dl>
+                    <p><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/strategie-accessibilite-fonction-publique-tdm.html" class="btn btn-success">Lire<span class="wb-inv"> Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</span></a></p>
+                </div>
+            </div>

--- a/src/fr/curriculum/writers-editors-translators.html
+++ b/src/fr/curriculum/writers-editors-translators.html
@@ -1,0 +1,281 @@
+---
+title: Rédacteurs, réviseurs et traducteurs
+layout: layouts/base.njk
+description: Cours sur l'accessibilité pour les rédacteurs, éditeurs et traducteurs
+---   
+<div class="well">
+    <ul>
+        <li><a href="#A313">Principes fondamentaux de la r&eacute;daction pour le Web (A313)</a></li>
+        <li><a href="#redaction-correction-epreuves">R&eacute;daction (et correction d'&eacute;preuves) pour le Web en tenant compte de l'accessibilit&eacute;</a></li>
+        <li><a href="#wcag2-word">Les WCAG 2 pour Word : documents et gabarits accessibles pour les fonctionnaires</a></li>
+        <li><a href="#PP-PDF">Cr&eacute;er des pr&eacute;sentations accessibles : de PowerPoint &agrave; PDF</a></li>
+        <li><a href="#spreadsheets">Feuilles de calcul accessibles</a></li>
+        <li><a href="#wcag2-office">WCAG 2 pour Office : de Word et PowerPoint &agrave; PDF</a></li>
+        <li><a href="#multimediaTeams">Accessibilit&eacute; &eacute;lectronique pour les &eacute;quipes multim&eacute;dias</a></li>
+        <li><a href="#rediger-web">R&eacute;diger pour le Web en tenant compte de l'accessibilit&eacute;</a></li>
+        <li><a href="#technologie-strategie">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</a></li>
+        <li><a href="#liste">Liste de contrôle des évaluations de la conformité de l'accessibilité (non Web / logiciel)</a></li>
+    </ul>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="A313" class="mrgn-tp-0">Principes fondamentaux de la r&eacute;daction pour le Web (A313).</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d'apprentissage :</dt>
+            <dd>
+                <p>Pour mieux r&eacute;pondre au nombre croissant de Canadiens qui utilisent Internet comme source de renseignements et de services, il devient essentiel pour les organismes gouvernementaux d'assurer une pr&eacute;sence Web efficace. Ce cours pr&eacute;sente aux nouveaux r&eacute;dacteurs pour le Web les pratiques exemplaires de la planification, de la r&eacute;daction et de la gestion de contenu Web. Les participants apprendront des techniques permettant de cr&eacute;er du contenu clair, facile &agrave; lire, et adapt&eacute; aux besoins de leur public cible.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://learn-apprendre.csps-efpc.gc.ca/">GCCampus</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Non indiqu&eacute;</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>7,5 heures</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En classe</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+        </dl>
+        <p><a href="https://learn-apprendre.csps-efpc.gc.ca/application/fr/content/principes-fondamentaux-de-la-redaction-pour-le-web-a313" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Principes fondamentaux de la r&eacute;daction pour le Web (A313).</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="redaction-correction-epreuves" class="mrgn-tp-0">R&eacute;daction (et correction d'&eacute;preuves) pour le Web en tenant compte de l'accessibilit&eacute; (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Familiarisez-vous avec les pratiques exemplaires ainsi qu'avec les r&egrave;gles, les lignes directrices et les normes &agrave; respecter pour r&eacute;diger et cr&eacute;er un contenu qui n'exclut personne.</p>
+                <p>Soyez convaincus d'avoir tout mis en &oelig;uvre pour d&eacute;clarer avec fiert&eacute; que votre contenu respecte, voire d&eacute;passe, les normes &eacute;tablies.</p>
+                <p>&Agrave; la fin du cours, vous obtiendrez les r&eacute;sultats d'apprentissage suivants :</p>
+                <ul>
+                    <li>Conna&icirc;tre les techniques que vous pouvez appliquer imm&eacute;diatement pour am&eacute;liorer l'accessibilit&eacute; de vos mots, de vos graphiques et de tout votre contenu multim&eacute;dia.</li>
+                    <li>Conna&icirc;tre en profondeur les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 du W3C, les WCAG 2.1, la norme PDF/UA, la <em>Loi de 2005 sur l'accessibilit&eacute; pour les personnes handicap&eacute;es de l'Ontario</em>, la loi en faveur des Am&eacute;ricains ayant un handicap, ainsi que d'autres normes d'accessibilit&eacute; en vigueur, et savoir s'y conformer.</li>
+                </ul>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une demi-journ&eacute;e, d'une journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/writing-for-web-accessibility/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour R&eacute;daction (et correction d'&eacute;preuves) pour le Web en tenant compte de l'accessibilit&eacute;</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="wcag2-word" class="mrgn-tp-0">Les WCAG 2 pour Word : documents et gabarits accessibles pour les fonctionnaires (en anglais seulement).</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>En collaboration avec d'autres sp&eacute;cialistes de l'accessibilit&eacute; et des ing&eacute;nieurs de Microsoft, nous avons mis au point ce cours complet et efficace qui pr&eacute;sente des astuces et des techniques que les participants pourront mettre en application imm&eacute;diatement pour rendre leurs documents Word accessibles.</p>
+                <p>Peu importe votre besoin (corriger des fichiers .doc et .docx ou cr&eacute;er un syst&egrave;me de gabarits Word qui tient compte des normes d'accessibilit&eacute;), ce cours vous expliquera en d&eacute;tail la marche &agrave; suivre pour rendre vos documents Word accessibles.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Connaissance interm&eacute;diaire de Microsoft Word</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une demi-journ&eacute;e, d'une journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/accessible-word-for-public-servants/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour les WCAG 2 pour Word </span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="PP-PDF" class="mrgn-tp-0">Cr&eacute;er des pr&eacute;sentations accessibles : de PowerPoint &agrave; PDF (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>&Agrave; la fin du cours, les participants seront en mesure de cr&eacute;er un fichier PowerPoint accessible (conforme aux WCAG 2, niveau AA) &agrave; l'aide de Microsoft PowerPoint.</dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Connaissance interm&eacute;diaire de Microsoft PowerPoint</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Une demi-journ&eacute;e, une journ&eacute;e compl&egrave;te ou sous forme d'expos&eacute; principal. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9xBCbQwEBAW6FGAHzfWlEIZwj4mt6OjvWsnr5RJ2jRZvDx4nVaoDEuHdtYnezHm8K_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTutENb3vuPnidclMF-2BrGRH42BcPmULKhMIGlPwsDb2y0WMJrpXv5qCRsE2DnKAda7HYIH-2BOBQUEHo2sreBfKYh9qpNvOShe5n28jBqMD2pu5Cp0mwNoeEYQMPU3zAAIuo9NrWc8MtS3KTA-2FIz-2FhPqY80Wuq4Cjf7-2BpGUDrbzKkbZ" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Cr&eacute;er des pr&eacute;sentations accessibles : de PowerPoint &agrave; PDF</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="spreadsheets" class="mrgn-tp-0">Feuilles de calcul accessibles (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>&Agrave; la fin du cours, les participants seront en mesure de cr&eacute;er une feuille de calcul accessible (conforme aux WCAG 2, niveau AA) en utilisant Microsoft Excel ou Google Sheets.</p>
+                <p>&Agrave; la fin du cours, les participants :</p>
+                <ul>
+                    <li>Conna&icirc;tront de nombreuses techniques qu'ils pourront appliquer imm&eacute;diatement pour rendre le contenu de leurs feuilles de calcul plus accessible.</li>
+                    <li>Conna&icirc;tront en profondeur les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 du W3C, ainsi que les politiques gouvernementales en vigueur en mati&egrave;re d'accessibilit&eacute;, et sauront s'y conformer.</li>
+                </ul>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd></dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Connaissance interm&eacute;diaire de Microsoft Excel et/ou de Google Sheets</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Demi-journ&eacute;e, journ&eacute;e compl&egrave;te, ou sous forme d'expos&eacute; principal. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9xBCbQwEBAW6FGAHzfWlEIXe3F5KZJw3wnbQG4NWmdUcWXkjVRrsVAnJxH24RQFA7_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTjNJNBUanJk1Hlj2miLr95XYLnXl1uw4F6caaNacsp3UrnFStObGxARd3SE1-2F6LIk5GOkuSgDlAUfDwFWliyS-2F-2BCoixTAiU6CWTfn8CVYSGs7SL685CEKr-2FGLy8gCti-2FLFm2MydyciqNO684KxdB6wcpLq8v9CEXiBHV3OEIG3RU" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Feuilles de calcul accessibles</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="wcag2-office" class="mrgn-tp-0">WCAG 2 pour Office : de Word et PowerPoint &agrave; PDF (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Ce cours pr&eacute;sente en d&eacute;tail les WCAG 2 du W3C (notamment les WCAG 2.0 et 2.1), ainsi que les crit&egrave;res de succ&egrave;s &eacute;tablis par la norme PDF/UA. Ces lignes directrices vous aideront &agrave; am&eacute;liorer l'efficacit&eacute; de vos documents Word, PowerPoint et PDF pour l'ensemble de votre public cible. Ce cours vous permettra &eacute;galement de vous familiariser avec les technologies d'assistance, qui aident les personnes ayant des incapacit&eacute;s et des difficult&eacute;s particuli&egrave;res.</p>
+                <p>Nos cours consistent en un examen approfondi de toutes les normes pertinentes permettant de se conformer aux politiques internationales, r&eacute;gionales ou du gouvernement f&eacute;d&eacute;ral, dont la loi en faveur des Am&eacute;ricains ayant un handicap et l'article r&eacute;vis&eacute; 508 (&Eacute;tats-Unis), la Norme sur l'accessibilit&eacute; des sites Web du Canada ou la <em>Loi de 2005 sur l'accessibilit&eacute; pour les personnes handicap&eacute;es de l'Ontario</em>.</p>
+                <p>Ce cours tient compte des principes d'apprentissage des adultes, propose des activit&eacute;s adapt&eacute;es &agrave; divers styles d'apprentissage, et remplit les conditions n&eacute;cessaires pour l'obtention de cr&eacute;dits d'&eacute;ducation permanente (certifi&eacute;s par des organisations comme le PPAC).</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>Interm&eacute;diaire</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Exp&eacute;rience de l'utilisation de Word et de PowerPoint. Il est recommand&eacute; de conna&icirc;tre les enjeux li&eacute;s &agrave; l'accessibilit&eacute; et les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 ou 2.1.</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Demi-journ&eacute;e ou journ&eacute;e compl&egrave;te. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9NQl07KNJA-2FkjfgzQ2sXW1iC0P7QOw-2BSP2KhQifrj4zH3tnbh3JSkXTRgoTzJRdpcRp5I-2FfeZ-2F6AI51NYQ2kGJZ171ITNjQFKl8PcPrwwOwk-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTsjpmdWznFsGoa-2FbIWO2qP0bu8vGdKI0AP98BbKwvfgYg0I0hO-2Bpan2ADQbGj3iGu9er1CDLxewVtpWMXjGatG0VEEJL5yO5siv658ioyHJvzpaTzEvHgBzd7KAu17oEz8JgMH9gLi2ixtz5aGLBkkjbtl7m8xpzF7hHF6cKXnGO" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour WCAG 2 pour Office : de Word et PowerPoint &agrave; PDF</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="multimediaTeams" class="mrgn-tp-0">Accessibilit&eacute; &eacute;lectronique pour les &eacute;quipes multim&eacute;dias (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Ce cours vous convaincra de l'importance que rev&ecirc;t l'accessibilit&eacute; et les normes s'y rapportant et des bienfaits qu'elles procurent &agrave; tout le monde. Il vous aidera &agrave; &eacute;largir votre public cible, &agrave; vous conformer &agrave; la loi, &agrave; r&eacute;duire vos co&ucirc;ts, ou tout simplement &agrave; respecter votre responsabilit&eacute; sociale. Le cours pr&eacute;sente en d&eacute;tail les crit&egrave;res de r&eacute;ussite pour le multim&eacute;dia, &eacute;tablis par les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2 du W3C (WCAG 2.0 et 2.1).</p>
+                <p>Notre mat&eacute;riel didactique consiste en un examen approfondi de toutes les normes pertinentes permettant de se conformer aux politiques internationales, r&eacute;gionales ou du gouvernement f&eacute;d&eacute;ral, dont la loi en faveur des Am&eacute;ricains ayant un handicap et l'article r&eacute;vis&eacute; 508 (&Eacute;tats-Unis), la Loi canadienne sur l'accessibilit&eacute; (dont l'adoption est imminente) ou la <em>Loi de 2005 sur l'accessibilit&eacute; pour les personnes handicap&eacute;es de l'Ontario</em>.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd></dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Exp&eacute;rience de l'utilisation de vid&eacute;os num&eacute;riques; il est recommand&eacute; de conna&icirc;tre les enjeux li&eacute;s &agrave; l'accessibilit&eacute; et les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 ou 2.1.</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Demi-journ&eacute;e ou journ&eacute;e compl&egrave;te. Nous offrons &eacute;galement ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne ou sur place</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://u5854113.ct.sendgrid.net/wf/click?upn=0jtiag-2FuRoxYSNS97-2B2LtlG1WAHsjIQ0Ep5-2BKjre2v6xtLg-2Ft-2FB6hhY0wDlCWyO9NQl07KNJA-2FkjfgzQ2sXW1iC0P7QOw-2BSP2KhQifrj4zGJZjYnOMz4u-2BFyuW0gjcDhrrXSM5FG4S-2FS2W4GU0e0NQ-3D-3D_mm4vR5b8-2B-2BzKspZM2ii0IcjwhTv4zZvwbUjYrxDq6DbqTQH4xzGYHIdjHRaFmoBOX8WE9BM2lzY1RalU0t4CTnRlu5L0ZZWX-2Fcu6ekFVsJ1Bz2qHdTVuzWy3ktVBNgvjkH-2Fx5bLwDTx5BfZ-2Ftxae68sPsV4j5A8Ccn6VRV-2FKonL1bhp-2Bd6be83gzXaYo-2FcbWMCAsTnDb2jJWS0EeQLnPYLk4bnN9ctWCNBxTLqIBHpD18KRsA96c1G1RJVtrKFGs" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour Accessibilit&eacute; &eacute;lectronique pour les &eacute;quipes multim&eacute;dias</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="rediger-web" class="mrgn-tp-0">R&eacute;diger pour le Web en tenant compte de l'accessibilit&eacute; (en anglais seulement)</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>&Agrave; la fin du cours, vous obtiendrez les r&eacute;sultats d'apprentissage suivants :</p>
+                <ul>
+                    <li>Conna&icirc;tre les techniques que vous pouvez appliquer imm&eacute;diatement pour am&eacute;liorer l'accessibilit&eacute; de vos mots, de vos graphiques et de tout votre contenu multim&eacute;dia.</li>
+                    <li>Conna&icirc;tre en profondeur les R&egrave;gles pour l'accessibilit&eacute; des contenus Web (WCAG) 2.0 du W3C, les WCAG 2.1, la norme PDF/UA, la Loi de 2005 sur l'accessibilit&eacute; pour les personnes handicap&eacute;es de l'Ontario, la loi en faveur des Am&eacute;ricains handicap&eacute;s, ainsi que d'autres normes d'accessibilit&eacute; en vigueur, et savoir s'y conformer.</li>
+                    <li>Parvenir &agrave; prendre des d&eacute;cisions &eacute;clair&eacute;es quant au niveau de conformit&eacute; aux normes d'accessibilit&eacute;.</li>
+                </ul>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>D&eacute;butant</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.wcag2.com/training">David Berman Communications (en anglais seulement)</a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>Cours d'une journ&eacute;e, d'une demi-journ&eacute;e ou sous forme d'expos&eacute; principal. Nous offrons ce cours en l'adaptant sur place aux besoins de votre organisation.</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>En ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>CAD330$ (rabais de groupe disponible)</dd>
+        </dl>
+        <p><a href="https://davidberman.com/courses/keynotes-and-courses/writing-for-web-accessibility/" class="btn btn-success">Inscrivez-vous<span class="wb-inv">&nbsp;pour R&eacute;diger pour le Web en tenant compte de l'accessibilit&eacute;</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="loi-canadienne" class="mrgn-tp-0">La loi canadienne sur l’accessibilité</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Fournir une base pour vous aider à comprendre les politiques existantes. Expliquer le but de la LCA et déterminer les principes pertinents pour les problèmes liés aux applications Web.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://laws-lois.justice.gc.ca/fra/">Site Web de Justice Canada </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://laws-lois.justice.gc.ca/fra/lois/A-0.6/" class="btn btn-success">Lire<span class="wb-inv"> La loi canadienne sur l’accessibilité</span></a></p>
+    </div>
+</div>
+<div class="panel panel-primary">
+    <div class="panel-body">
+        <h3 id="technologie-strategie" class="mrgn-tp-0">Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</h3>
+        <dl class="dl-horizontal">
+            <dt>Objectif d&rsquo;apprentissage :</dt>
+            <dd>
+                <p>Améliorer votre compréhension de l’état souhaité du gouvernement du Canada en matière d’accessibilité technologique pour les clients et les employés. Expliquer ce que fait le gouvernement du Canada pour améliorer l’accessibilité à l’aide de la technologie.</p>
+            </dd>
+            <dt>Niveau :</dt>
+            <dd>N/A</dd>
+            <dt>Fournisseur :</dt>
+            <dd><a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Site Web du Conseil du Trésor du Canada  </a></dd>
+            <dt>Pr&eacute;alables :</dt>
+            <dd>Aucun</dd>
+            <dt>Dur&eacute;e :</dt>
+            <dd>N/A</dd>
+            <dt>Mode de prestation :</dt>
+            <dd>Lecture en ligne</dd>
+            <dt>Estimation du co&ucirc;t :</dt>
+            <dd>Gratuit</dd>
+            <dt>Langue :</dt>
+            <dd>Français ou Anglais</dd>
+        </dl>
+        <p><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/strategie-accessibilite-fonction-publique-tdm.html" class="btn btn-success">Lire<span class="wb-inv"> Technologie : Stratégie sur l’accessibilité au sein de la fonction publique du Canada</span></a></p>
+    </div>
+</div>


### PR DESCRIPTION
Moving Accessibility Curriculum from ESDC to DAT:
https://bati-itao.github.io/learning/curriculum/index.html

to:
/en/curriculum
/fr/curriculum

Progress by Kellyanne