### PR TITLE
Adding information about Useful Links

### DIFF
--- a/src/en/bookmarks/index.html
+++ b/src/en/bookmarks/index.html
@@ -1,0 +1,178 @@
+---
+title: Useful Links
+layout: layouts/base.njk
+description: This page contains a list of key links for ESDC's IT Accessibility Office.
+---
+				<table class="wb-tables table table-striped table-hover">
+
+					<thead>
+						<tr>
+							<th>Title</th>
+							<th>Description</th>
+							<th>Category</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><a href="https://incl.ca/archives/">Part of a Whole</a></td>
+							<td>Nicolas Steenhout writes about accessibility.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.smashingmagazine.com/2020/06/accessible-video-conferencing-tools/">Which Video Conferencing Tools Are Most Accessible?</a></td>
+							<td>In this article, Claudio Luis Vera explains what to keep in mind when choosing between video conferencing tools to benefit everyone on your team — including those with disabilities.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://blog.timroesner.com/accessibility-best-practices">Accessibility Best Practices</a></td>
+							<td>Accessibility is an important corner stone of iOS development. It enables all people to use your apps, no matter their abilities. Fortunately UIKit offers many APIs, which allow Developers to offer support for system technologies within their apps.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">Centrally Deployed Templates Solution (CDTS)</a></td>
+							<td>The purpose of the <abbr title="Centrally Deployed Templates Solution">CDTS</abbr> is essentially to deliver the presentation layer of the Canada.ca theme or Intranet.canada.ca theme to web assets.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://wet-boew.github.io/v4.0-ci/index-en.html" >Web Experience Toolkit (WET)</a></td>
+							<td>An award-winning front-end framework for building websites that are accessible, usable, interoperable, mobile friendly and multilingual</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-style-guide.html" >Canada.ca Content Style Guide</a></td>
+							<td>These are the rules to create web content that can be easily found, understood and used. They are based on writing principles and techniques that help make web content clear and adapted to the needs of all people. </td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification.html">Canada.ca Content and Information Architecture Specification</a></td>
+							<td>The Canada.ca design system provides user-tested templates, patterns and design principles. The system allows designers and developers to create a more usable, consistent and trustworthy online experience for people who access Government of Canada digital services.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://a11y-style-guide.com/style-guide/">A11Y Style Guide</a></td>
+							<td>This application is a living style guide or pattern library, generated from KSS documented styles...with an accessibility twist.</td>
+							<td>Style guide</td>
+						</tr>
+						<tr>
+							<td><a href="https://design-system.service.gov.uk/patterns/dates/" >Asking users for dates</a></td>
+							<td>Follow this pattern whenever you need users to provide or select a date as part of your service.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://t716.bitbucket.io/index-en.html">Web accessibility for Canada.ca (CSPS - T716)</a></td>
+							<td>This course outlines federal standards and guidelines on web accessibility and emphasizes the requirements, roles and responsibilities for compliance with this standard. Participants will learn how to assess and apply WCAG 2.0 in a consistent manner throughout the Canada.ca web pages under the Web Renewal Initiative.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://accessibility.18f.gov/">18F Accessibility Guide </a></td>
+							<td>Accessibility guide developed by the US Government.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://davatron5000.github.io/a11y-nutrition-cards/" >Nutrition Cards for Accessible Components</a></td>
+							<td>A11Y Nutrition Cards is an attempt to digest and simplify the accessibility expectations when it comes to component authoring.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.a11yproject.com/">The A11Y Project</a></td>
+							<td>The A11Y Project is a community-driven effort to make digital accessibility easier.</td>
+							<td>Style guide</td>
+						</tr>
+						<tr>
+							<td><a href="https://digital.canada.ca/a11y/">CDS Accessibility Handbook</a></td>
+							<td>The Canadian Digital Service is committed to building accessible and inclusive services. Building accessible services means meeting the needs of as many people as possible.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.accessibilityassociation.org/">International Association of Accessibility Professionals</a></td>
+							<td>Accessibility professionals from around the world come together to define, promote and improve the accessibility profession through networking, education and certification.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.canada.ca/en/employment-social-development/programs/disability/arc/inclusive-meetings.html">Guide to Planning Inclusive Meetings</a></td>
+							<td>Well-planned meetings are an essential communication tool for any organization. Meetings in the workplace and in volunteer and community groups regularly bring people together to share information, develop strategies, work toward common goals and celebrate successes.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32620">Guideline on Making Information Technology Usable by All</a></td>
+							<td>This guideline supports the Government of Canada’s direction to ensure that departments, agencies and organizations consider accessibility in the acquisition or development of information technology (IT) solutions and equipment to make IT usable by all.</td>
+							<td>Policy</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf">EU EN 301 549 (Managing accessibility in the public procurement of ICT)</a></td>
+							<td>Accessibility requirements suitable for public procurement of ICT products and services in Europe.</td>
+							<td>Policy</td>
+						</tr>
+						<tr>
+							<td><a href="https://intranet.canada.ca/wg-tg/gc-cg/accessible-communications-accessibles/str-sor-eng.asp">General accessibility services, tools and resources listing</a></td>
+							<td>Learn about the services, tools and resources for making communications products and activities accessible.</td>
+							<td>Listing</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/making-communications-accessible.html">Making communications accessible in the Government of Canada</a></td>
+							<td>Accessibility is about respecting differences and removing barriers so that everyone can participate.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://wiki.gccollab.ca/M365/Home/Accessibility">M365 accessibility</a></td>
+							<td>List of resources and learning material on M365 accessibility.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.a11yportal.com/">Accessibility Portal</a></td>
+							<td>Our believe is that digital equality is a human right for websites, mobile applications, and digital content. But it doesn’t stop there. We need to do it for quality, innovation, compliance, relations, user experience and much much more.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://developer.paciellogroup.com/blog/2017/07/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">Short note on aria-label, aria-labelledby, and aria-describedby</a></td>
+							<td>Be careful when you use the aria-label, aria-labelledby, and aria-describedby attributes, because they do not work consistently with all HTML elements.</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.youtube.com/playlist?list=PLIl2EzNYri0cLtSlZowttih25VnSvWITu">YouTube: Apple: Accessibility</a></td>
+							<td>From using your iPhone without seeing the screen, to adapting gestures to your physical needs, discover how the accessibility features built into your Apple devices can help you do more.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://kb.iu.edu/d/bgdz">Screen reader considerations when choosing between Google at IU My Drive and Microsoft OneDrive at IU</a></td>
+							<td>The choice between Google at IU My Drive and Microsoft OneDrive at IU isn't simple when considering screen reader accessibility. There are pros and cons to both, which can differ depending on the screen reader and browser combination used.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://www.tempertemper.net/">The web, design, and accessibility – tempertemper</a></td>
+							<td>I’m Martin, a user interface and interaction designer, lover of HTML and CSS, and co-founder of Frontend NE. Here’s a wee bit more about me and what I’m up to.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://guia-wcag.com/en/">Web Content Accessibility Guide</a></td>
+							<td>The fundamental basis for you to have truly inclusive and accessible digital products.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://de.ryerson.ca/wa/maze.html">Accessibility Maze: a fun game to learn about web accessibility</a></td>
+							<td>Ryerson University created the Accessibility Maze, a fun game, to help people new to web accessibility practise and learn more on barriers and challenges that people with disabilities usually experience when navigating the Web. The game provides quick lessons on how to avoid those barriers or correct them.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://wet-boew.github.io/v4.0-ci/demos/wamethod/wamethod-AA-en.html">Web Accessibility Assessment Methodology (Level AA)</a></td>
+							<td>Assist with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.1 Level A and Level AA Success Criteria</td>
+							<td>Development</td>
+						</tr>
+						<tr>
+							<td><a href="https://a11y.canada.ca/en/">Digital Accessibility Toolkit</a></td>
+							<td>Digital accessibility resources for public servants, by public servants.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://github.com/accessibility/a11y-courses">Accessibility Courses</a></td>
+							<td>Courses, webinars, educational videos, and more, offered in web accessibility.</td>
+							<td>Learning</td>
+						</tr>
+						<tr>
+							<td><a href="https://a11ysupport.io/">Accessibility Support</a></td>
+							<td>Check if your code will work with assistive technologies.</td>
+							<td>Development</td>
+						</tr>
+					</tbody>
+				</table>
+                

--- a/src/fr/bookmarks/index.html
+++ b/src/fr/bookmarks/index.html
@@ -1,0 +1,176 @@
+---
+title: Liens utiles
+layout: layouts/base.njk
+description: Cette page contient une liste de liens utiles pour le bureau d'accessibilité informatique de l'ESDC.
+---
+<table class="wb-tables table table-striped table-hover">
+    <thead>
+        <tr>
+            <td>Titre</td>
+            <td>Description</td>
+            <td>Cat&eacute;gorie</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://incl.ca/fr/archives-2/">Partie d'un tout</a></td>
+            <td>Nicolas Steenhout rédige au sujet de l’accessibilité.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.smashingmagazine.com/2020/06/accessible-video-conferencing-tools/" hreflang="en">Quels outils de vidéoconférence sont les plus accessibles?</a></td>
+            <td>Dans cet article, Claudio Luis Vera explique ce qu’il faut garder à l’esprit lors du choix d’un outil de vidéoconférence pour que tous les membres de votre équipe puissent en profiter — notamment ceux avec des handicaps.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://blog.timroesner.com/accessibility-best-practices" hreflang="en">Solution de gabarits à déploiement centralisé (SGDC) (Disponible en anglais seulement)</a></td>
+            <td>L’accessibilité est une pierre angulaire importante du développement iOS. Elle permet à tous d’utiliser vos applications, peu importe leurs handicaps. Heureusement, UIKit offre plusieurs API, qui permettent aux développeurs d’offrir un soutien aux technologies des systèmes au sein de leurs applications.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-fr.html">Solution de gabarits à déploiement centralisé (SGDC)</a></td>
+            <td>L’objectif de la SGDC consiste essentiellement à fournir la couche de présentation du thème de Canada.ca ou du thème d’Intranet.canada.ca aux actifs Web.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://wet-boew.github.io/v4.0-ci/index-fr.html">Boîte à outils de l’expérience Web</a></td>
+            <td>Cette plateforme frontale primée permet de créer des sites Web qui sont accessibles, faciles d’emploi, interopérables, adaptés aux appareils mobiles et multilingues.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/guide-redaction-contenu-canada.html">Guide de style du contenu de Canada.ca</a></td>
+            <td>Ce sont les règles à suivre pour créer du contenu Web qui peut être facilement trouvé, compris et utilisé. Elles reposent sur des principes et des techniques de rédaction qui permettent de rendre le contenu Web clair et adapté aux besoins de tous.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/specifications-contenu-architecture-information-canada.html">Spécifications sur le contenu et l’architecture de l’information du site Canada.ca</a></td>
+            <td>Le système de conception de Canada.ca fournit des modèles mis à l’essai par l’utilisateur, des patrons et des principes de conception. Le système permet aux concepteurs et aux développeurs de créer une expérience en ligne plus conviviale, plus cohérente et plus digne de confiance pour les personnes qui accèdent aux services numériques du gouvernement du Canada.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://a11y-style-guide.com/style-guide/" hreflang="en">Guide de style A11Y (Disponible en anglais seulement)</a></td>
+            <td>Cette application est un guide de style vivant ou une bibliothèque de modèles, générée à partir de styles documentés KSS… avec une touche d’accessibilité.</td>
+            <td>Guide de style</td>
+        </tr>
+        <tr>
+            <td><a href="https://design-system.service.gov.uk/patterns/dates/" hreflang="en">Demander des dates aux utilisateurs (Disponible en anglais seulement)</a></td>
+            <td>Suivez ce modèle chaque fois que vous avez besoin que les utilisateurs fournissent ou sélectionnent une date dans le cadre de votre service.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://t716.bitbucket.io/index-fr.html">Accessibilité des sites Web de Canada.ca (CSPS - T716)</a></td>
+            <td>Ce cours décrit les normes et les lignes directrices fédérales en matière d’accessibilité des sites Web, en mettant l’accent sur les exigences, les rôles et les responsabilités touchant la conformité à la norme. Les participants apprendront à évaluer et à appliquer WCAG 2.0 de manière cohérente dans les pages Web de Canada.ca dans le cadre de l’Initiative de renouvellement du Web.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://accessibility.18f.gov/" hreflang="en">18F Accessibility Guide (Disponible en anglais seulement)</a></td>
+            <td>Guide d’accessibilité élaboré par le gouvernement des États-Unis d’Amérique.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://davatron5000.github.io/a11y-nutrition-cards/" hreflang="en">Fiches nutritionnelles pour les composantes accessibles (Disponible en anglais seulement)</a></td>
+            <td>Les fiches nutritionnelles A11Y est une tentative de digérer et de simplifier les attentes en matière d’accessibilité lorsqu’il s’agit de la création de composantes.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.a11yproject.com/" hreflang="en">Le projet A11Y (Disponible en anglais seulement)</a></td>
+            <td>Le projet A11Y est un effort communautaire visant à faciliter l’accessibilité numérique.</td>
+            <td>Guide de style</td>
+        </tr>
+        <tr>
+            <td><a href="https://numerique.canada.ca/a11y/">Manuel de l’accessibilité du Service numérique canadien</a></td>
+            <td>Le Service numérique canadien s’engage à mettre en place des services accessibles et inclusifs. La mise en place de services accessibles signifie de répondre aux besoins du plus grand nombre de personnes possible.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.accessibilityassociation.org/" hreflang="en">International Association of Accessibility Professionals (Disponible en anglais seulement) </a></td>
+            <td>Les professionnels de l’accessibilité du monde entier se réunissent pour définir, promouvoir et améliorer la profession de l’accessibilité par le biais du réseautage, de l’éducation et de la certification.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.canada.ca/fr/emploi-developpement-social/programmes/invalidite/cra/reunions-inclusives.html">Guide pour l’organisation de réunions inclusives</a></td>
+            <td>Les réunions bien planifiées sont un outil de communication essentiel pour toute organisation. Les réunions en milieu de travail et dans les groupes de bénévoles et les groupes communautaires rassemblent régulièrement des personnes pour partager des informations, élaborer des stratégies, travailler vers des objectifs communs et célébrer les réussites.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=32620">Directive visant à rendre les technologies de l’information utilisables par tous</a></td>
+            <td>Cette ligne directrice soutient la direction du gouvernement du Canada pour s’assurer que les ministères, les agences et les organisations prennent en compte l’accessibilité lors de l’acquisition ou du développement d’équipement et de solutions de la technologie de l’information (TI) pour rendre la TI utilisable par tous.</td>
+            <td>Politique</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf" hreflang="en">EU EN 301 549 (Gestion de l’accessibilité dans les marchés publics des TIC) (Disponible en anglais seulement)</a></td>
+            <td>Les exigences en matière d’accessibilité qui conviennent à l’approvisionnement, par les organismes publics, de produits et services de technologies de l’information et des communications (TIC) en Europe.</td>
+            <td>Politique</td>
+        </tr>
+        <tr>
+            <td><a href="https://intranet.canada.ca/wg-tg/gc-cg/accessible-communications-accessibles/str-sor-fra.asp">Liste des ressources, outils et services d’accessibilité générale</a></td>
+            <td>Découvrez les services, les outils et les ressources qui permettent de créer des produits de communication et des activités accessibles.</td>
+            <td>Liste</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/sujets/communications-gouvernementales/assurer-accessibilite-communications.html">Rendre les communications accessibles au sein du gouvernement du Canada</a></td>
+            <td>L’accessibilité consiste à respecter les différences et à supprimer les obstacles afin que chacun puisse participer.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://wiki.gccollab.ca/M365/Home/Accessibility" hreflang="en">Accessibilité de M365 (Disponible en anglais seulement)</a></td>
+            <td>Liste des ressources et du matériel d’apprentissage sur l’accessibilité de Microsoft 365 (M365).</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.a11yportal.com/" hreflang="en">Portail de l’accessibilité (Disponible en anglais seulement)</a></td>
+            <td>Nous pensons que l’égalité numérique est un droit de l’homme pour les sites Web, les applications mobiles et le contenu numérique. Toutefois, cela ne s’arrête pas là. Nous devons faire cela pour la qualité, l’innovation, la conformité, les relations, l’expérience utilisateur et plus encore.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/" hreflang="en">Brève remarque sur aria-label, aria-labelledby et aria-describedby (Disponible en anglais seulement)</a></td>
+            <td>Faites attention lorsque vous utilisez les caractéristiques aria-label, aria-labelledby et aria-describedby, parce qu’ils ne fonctionnent pas de manière cohérente avec tous les éléments HTML.</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.youtube.com/playlist?list=PLIl2EzNYri0cLtSlZowttih25VnSvWITu" hreflang="en">YouTube : Apple : Accessibilité (Disponible en anglais seulement)</a></td>
+            <td>De l’utilisation de votre iPhone sans voir l’écran, à l’adaptation des gestes à vos besoins physiques, découvrez comment les fonctionnalités d’accessibilité intégrées à vos appareils Apple peuvent vous aider à en faire plus.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://kb.iu.edu/d/bgdz" hreflang="en">Considérations relatives aux lecteurs d’écran lors du choix entre Google à IU My Drive et Microsoft OneDrive à IU (Disponible en anglais seulement)</a></td>
+            <td>Le choix entre Google à IU My Drive et Microsoft OneDrive à IU n’est pas simple lorsqu’on considère l’accessibilité relative aux lecteurs d’écran. Les deux présentent des avantages et des inconvénients, qui peuvent varier en fonction de la combinaison du lecteur d’écran et du navigateur utilisé.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://www.tempertemper.net/" hreflang="en">Le Web, la conception et l’accessibilité (Disponible en anglais seulement)</a></td>
+            <td>Je suis Martin, un concepteur d’interface utilisateur et d’interaction, amateur de HTML et de CSS, et cofondateur de Frontend NE. Voici un peu plus d’informations à mon sujet et sur ce que je fais.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://guia-wcag.com/en/" hreflang="en">Guide d'accessibilité du contenu Web (Disponible en anglais seulement)</a></td>
+            <td>La base fondamentale qui vous permettra de disposer de produits numériques réellement inclusifs et accessibles.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://de.ryerson.ca/wa/maze.html" hreflang="en">Accessibility Maze : un jeu amusant pour en savoir plus sur l'accessibilité Web (Disponible en anglais seulement)</a></td>
+            <td>L'Université Ryerson a créé Accessibility Maze, un jeu amusant, pour aider les personnes débutantes en accessibilité Web à s’exercer et apprendre davantage sur les obstacles et les défis auxquels les personnes ayant un handicap sont généralement confrontées lorsqu'elles naviguent dans Internet. Le jeu fournit des leçons rapides sur la façon d'éviter ces obstacles ou de les corriger. </td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://wet-boew.github.io/v4.0-ci/demos/wamethod/wamethod-AA-fr.html" hreflang="en">Méthodologie d’évaluation sur l’accessibilité des sites Web (niveau AA)</a></td>
+            <td>Aider à mesurer les critères de succès de niveau A et AA des Règles pour l’accessibilité des contenus Web (WCAG) 2.1 (anglais seulement).</td>
+            <td>Développement</td>
+        </tr>
+        <tr>
+            <td><a href="https://a11y.canada.ca/fr/">Ressources d'accessibilité numérique pour les fonctionnaires</a></td>
+            <td>Ressources d'accessibilité numérique pour les fonctionnaires, par les fonctionnaires.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://github.com/accessibility/a11y-courses" hreflang="en">Cours d'accessibilité</a></td>
+            <td>Cours, webinaires, vidéos éducatives, et plus encore, proposés en accessibilité web.</td>
+            <td>Apprentissage</td>
+        </tr>
+        <tr>
+            <td><a href="https://a11ysupport.io/" hreflang="en">Soutien d'accessibilité (Disponible en anglais seulement)</a></td>
+            <td>Vérifier si votre code fonctionnera avec les technologies d'assistance.</td>
+            <td>Développement</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Moving Useful Links from ESDC to DAT:
https://bati-itao.github.io/resources/bookmarks.html

to:
/en/bookmarks/
/fr/bookmarks/

From the old PR: Added hrelang="en" in the french page and I removed the icon (the only one left is a link of GOC)

Progress by Kellyanne