### PR TITLE
fix about breadcrumbs

### DIFF
--- a/src/en/about/organizations/organizations.json
+++ b/src/en/about/organizations/organizations.json
@@ -1,10 +1,6 @@
 {
 	"breadcrumbs": [
 		{
-			"title": "Who we are?",
-			"link": "/en/about/"
-		},
-		{
 			"title": "Government departments working in accessibility",
 			"link": "/en/about/organizations/"
 		}

--- a/src/fr/about/organizations/organizations.json
+++ b/src/fr/about/organizations/organizations.json
@@ -1,10 +1,6 @@
 {
 	"breadcrumbs": [
 		{
-			"title": "Qui sommes-nous ?",
-			"link": "/fr/about/"
-		},
-		{
 			"title": "Les ministères travaillant dans le domaine de l'accessibilité",
 			"link": "/fr/about/organizations/"
 		}


### PR DESCRIPTION
Breadcrumbs for who we are is repeated.

https://a11y.canada.ca/en/about/organizations/

![image](https://user-images.githubusercontent.com/2575266/170739082-f8347c80-9edb-43ec-85cc-deb1f28b97f1.png)

Fixed in this PR:

https://deploy-preview-162--a11ycanada.netlify.app/en/about/organizations/