### PR TITLE
Add cra learning path

### DIFF
--- a/src/en/cra/index.html
+++ b/src/en/cra/index.html
@@ -1173,3 +1173,5 @@ description: The following learning paths provide accessibility training to meet
 
             <!-- Container End -->
         </div>
+    </div>
+</div>


### PR DESCRIPTION
Moving CRA Learning Paths from ITAO to DAT:
https://bati-itao.github.io/cra/index.html

Location in DAT:
/en/cra/index.html

Notes:
- Please check the description. There wasn't a fitting description on the page so I added a generic description that will most likely need to be updated.