### PR TITLE
Fixed inaccessible table on CRA Accessibility Learning Paths page

### DIFF
--- a/src/en/cra/index.html
+++ b/src/en/cra/index.html
@@ -28,11 +28,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -144,11 +144,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -236,11 +236,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -300,11 +300,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -469,11 +469,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -556,11 +556,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -689,11 +689,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -753,11 +753,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -818,11 +818,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -898,11 +898,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -1060,11 +1060,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -1140,11 +1140,11 @@ description: The following learning paths provide accessibility training to meet
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <td>No.</td>
-                            <td>Activity</td>
-                            <td>Method(s)</td>
-                            <td>Duration</td>
-                            <td>Instructions/Materials</td>
+                            <th scope="col">No.</th>
+                            <th scope="col">Activity</th>
+                            <th scope="col">Method(s)</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Instructions/Materials</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
Made the tables on the  CRA Accessibility Learning Paths page accessible by replacing td element with <th scope="col"></th> .

