### PR TITLE
move How to ... section to the top of page

### DIFF
--- a/src/_includes/partials/standard-alert.njk
+++ b/src/_includes/partials/standard-alert.njk
@@ -1,0 +1,29 @@
+<section class="alert alert-info mrgn-tp-lg">
+	{% if locale == "en" %}
+
+## How to get involved?
+
+To foster a participative engagement process, select stakeholders will be invited to:
+
+- Review the _[Standard on Information and Communication Technologies (<abbr title="Information and Communication Technology">ICT</abbr>) Accessibility](./standard)_ in full, the proposed accessibility requirements and the associated implementation timelines
+- Consult the [background document](./backgrounder) with a description of each requirement
+- Submit your confidential and anonymous feedback by completing our [feedback submission form](https://forms.office.com/Pages/ResponsePage.aspx?id=EN-XY5VFR0CcTwMxEoIVK5_R18YD5b5JpOR8T_7y9oxUOUlVWVY5TVlBUDlJU0VPRlNLV0ZINlhDSCQlQCN0PWcu)
+
+In the event of technical difficulties, stakeholders will be able to contact us through our generic mailbox: <DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca>
+
+		{% else %}
+
+## Façons de participer
+
+Pour favoriser un processus d'engagement participatif, certains intervenants seront invités&nbsp;:
+
+- à examiner la [_Norme d'accessibilité des technologies de l'information et des communications (<abbr title="technologies de l’information et des communications">TIC</abbr>)_](./standard) dans son intégralité, les exigences en matière d'accessibilité proposées ainsi que les délais de mise en œuvre associés;
+- à consulter le [document d'information](./backgrounder), qui donne une description de chaque exigence;
+- à envoyer leur rétroaction confidentielle et anonyme en remplissant [notre formulaire d'envoi de rétroaction](https://forms.office.com/Pages/ResponsePage.aspx?id=EN-XY5VFR0CcTwMxEoIVK5_R18YD5b5JpOR8T_7y9oxUOUlVWVY5TVlBUDlJU0VPRlNLV0ZINlhDSCQlQCN0PWcu).
+
+**Lorsque vous cliquez sur le lien, cliquer sur « Français » dans le coin supérieur droit de la page Web pour accéder à la version française du formulaire.**
+
+En cas de difficultés techniques, les intervenants pourront communiquer avec nous en utilisant notre boîte aux lettres générique : [DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca](mailto:DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca)
+
+	{% endif %}
+</section>

--- a/src/en/standards/index.md
+++ b/src/en/standards/index.md
@@ -4,6 +4,8 @@ layout: layouts/base.njk
 description: "The Digital Policy Division at the Treasury Board of Canada Secretariat is seeking targeted input on Phase One of the <a href='./standard'><em>Standard on Information and Communications Technology (<abbr title='Information and Communication Technology'>ICT</abbr>) Accessibility</em></a>. This webpage is where you can provide feedback to help make the Government of Canada’s <abbr title='Information and Communication Technology'>ICT</abbr> usable by all."
 ---
 
+{% include "partials/standard-alert.njk" %}
+
 Feedback will be accepted until **<time datetime="2022-11-30">November 30th, 2022</time>**.
 
 ## What is <abbr title="Information and Communication Technology">ICT</abbr>?
@@ -32,16 +34,6 @@ The Government of Canada’s [_Standard on <abbr title="Information and Communic
 We are harmonizing with the _Harmonised European Standard_ to provide a framework to update accessibility requirements over time. This harmonization will help Canada become a global leader in <abbr title="Information and Communication Technology">ICT</abbr> accessibility and will enable the Canadian federal public service to identify, remove and prevent accessibility barriers to new, existing and future <abbr title="Information and Communication Technology">ICT</abbr>.
 
 Phase One of the Standard will focus on foundational elements of <abbr title="Information and Communication Technology">ICT</abbr> accessibility, including requirements for new <abbr title="Information and Communication Technology">ICT</abbr>, most assessments, training, performance and reporting and user feedback.
-
-## How to get involved?
-
-To foster a participative engagement process, select stakeholders will be invited to:
-
-- Review the _[Standard on Information and Communication Technologies (<abbr title="Information and Communication Technology">ICT</abbr>) Accessibility](./standard)_ in full, the proposed accessibility requirements and the associated implementation timelines
-- Consult the [background document](./backgrounder) with a description of each requirement
-- Submit your confidential and anonymous feedback by completing our [feedback submission form](https://forms.office.com/Pages/ResponsePage.aspx?id=EN-XY5VFR0CcTwMxEoIVK5_R18YD5b5JpOR8T_7y9oxUOUlVWVY5TVlBUDlJU0VPRlNLV0ZINlhDSCQlQCN0PWcu)
-
-In the event of technical difficulties, stakeholders will be able to contact us through our generic mailbox: <DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca>
 
   ## Important dates
 

--- a/src/en/standards/standard.md
+++ b/src/en/standards/standard.md
@@ -4,6 +4,8 @@ layout: layouts/base.njk
 description: "This page displays the Standard on Information and Communication Technologies (<abbr>ICT</abbr>) Accessibility in full, the various accessibility requirements and the associated implementation timelines"
 ---
 
+{% include "partials/standard-alert.njk" %}
+
 Last updated: October 18, 2022
 
 <ol class="a11y-standards-list">

--- a/src/fr/standards/index.md
+++ b/src/fr/standards/index.md
@@ -3,6 +3,9 @@ title: "Séance de mobilisation ciblée : L’ébauche de la <em>Norme d’acces
 layout: layouts/base.njk
 description: "La Division de la politique numérique du Secrétariat du Conseil du Trésor souhaite obtenir des renseignements ciblés sur la première phase de la <a href='./standard'><em>Norme d’accessibilité des technologies de l’information et des communications (<abbr title='technologies de l’information et des communications'>TIC</abbr>)</em></a>. Ce site Web est l’endroit où vous pouvez fournir une rétroaction pour aider à rendre les <abbr title='technologies de l’information et des communications'>TIC</abbr> du gouvernement du Canada utilisables par tous."
 ---
+
+{% include "partials/standard-alert.njk" %}
+
 La rétroaction sera acceptée jusqu'au **30 novembre 2022**.
 
 ## Que sont les <abbr title="technologies de l’information et des communications">TIC</abbr>?
@@ -32,18 +35,6 @@ La [_Norme d'accessibilité des <abbr title="technologies de l’information et 
 Nous harmonisons notre [_Norme d'accessibilité des <abbr title="technologies de l’information et des communications">TIC</abbr>_](./standard) avec la _Norme européenne harmonisée_ dans le but de mettre en place un cadre permettant de mettre à jour les exigences en matière d'accessibilité au fil du temps. Cette harmonisation aidera le Canada à devenir un chef de file mondial en matière d'accessibilité des <abbr title="technologies de l’information et des communications">TIC</abbr> et permettra à la fonction publique fédérale canadienne de repérer, d'éliminer et de prévenir les obstacles à l'accessibilité des <abbr title="technologies de l’information et des communications">TIC</abbr> nouvelles, existantes et futures.
 
 La première phase met l'accent sur les éléments fondamentaux de l'accessibilité des <abbr title="technologies de l’information et des communications">TIC</abbr>, y compris les exigences relatives aux nouvelles <abbr title="technologies de l’information et des communications">TIC</abbr>, à la plupart des évaluations, à la formation, au rendement et à la rétroaction des utilisateurs.
-
-## Façons de participer
-
-Pour favoriser un processus d'engagement participatif, certains intervenants seront invités&nbsp;:
-
-- à examiner la [_Norme d'accessibilité des technologies de l'information et des communications (<abbr title="technologies de l’information et des communications">TIC</abbr>)_](./standard) dans son intégralité, les exigences en matière d'accessibilité proposées ainsi que les délais de mise en œuvre associés;
-- à consulter le [document d'information](./backgrounder), qui donne une description de chaque exigence;
-- à envoyer leur rétroaction confidentielle et anonyme en remplissant [notre formulaire d'envoi de rétroaction](https://forms.office.com/Pages/ResponsePage.aspx?id=EN-XY5VFR0CcTwMxEoIVK5_R18YD5b5JpOR8T_7y9oxUOUlVWVY5TVlBUDlJU0VPRlNLV0ZINlhDSCQlQCN0PWcu).
-
-**Lorsque vous cliquez sur le lien, cliquer sur « Français » dans le coin supérieur droit de la page Web pour accéder à la version française du formulaire.**
-
-En cas de difficultés techniques, les intervenants pourront communiquer avec nous en utilisant notre boîte aux lettres générique : [DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca](mailto:DigitalPolicy.PolitiqueNumerique-Consultation@tbs-sct.gc.ca)
 
 ## Dates importantes
 

--- a/src/fr/standards/standard.md
+++ b/src/fr/standards/standard.md
@@ -4,6 +4,8 @@ layout: layouts/base.njk
 description: "Cette page présente la <em>Norme d’accessibilité des technologies de l’information et des communications (<abbr>TIC</abbr>)</em> dans son intégralité, les exigences en matière d’accessibilité ainsi que les délais de mise en œuvre associés"
 ---
 
+{% include "partials/standard-alert.njk" %}
+
 Dernière mise à jour : Le 4 octobre 2022
 
 <ol class="a11y-standards-list">


### PR DESCRIPTION
Move the How to get involved section to the top of the information and standard pages to make it more findable.

![image](https://user-images.githubusercontent.com/2575266/201132216-a8ebb8af-f265-46d7-881e-34574a0fadcd.png)

