### PR TITLE
Dev variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+**/node_modules/**
 jspm_packages/
 
 # TypeScript v1 declaration files

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "sass-build": "sass --style=compressed src/_scss/base.scss _site/css/da11yn.css",
     "watch:sass": "npm run sass-start -- --watch",
     "start": "npm-run-all sass-start --parallel watch:*",
+    "dev": "ELEVENTY_ENV=dev npm-run-all sass-build --parallel eleventy",
     "build": "npm-run-all sass-build --parallel eleventy"
   },
   "repository": {

--- a/src/_data/settings.js
+++ b/src/_data/settings.js
@@ -1,5 +1,6 @@
 module.exports = {
 	buildTime: new Date(),
+	env: process.env.ELEVENTY_ENV,
 	baseUrl: "/",
 	en: {
 	  metaTitle: "Digital Accessibility Toolkit / Sharing space"
@@ -7,4 +8,4 @@ module.exports = {
 	fr: {
 	  metaTitle: "Boîte à outils d'accessibilité numérique / Espace de partage"
 	}
-  };
+};

--- a/src/_includes/partials/contribute.njk
+++ b/src/_includes/partials/contribute.njk
@@ -1,13 +1,16 @@
-
 {# {{ footer[locale].aboutThisSite }} #}
 <aside class="contribute">
 	<div class="container">
 		<h2><i class="fab fa-github fa-lg fa-fw" aria-hidden="true"></i>{{ contribute[locale].contribute }} <small>{{ contribute[locale].small }}</small></h2>
-			<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+		<ul class="list-unstyled colcount-sm-2 colcount-md-3">
 				<li><i class="fas fa-code fa-lg fa-fw" aria-hidden="true"></i><a {% if locale != en %} hreflang="en" {% endif %}href="https://github.com/gc-da11yn/gc-da11yn.github.io">{{ contribute[locale].see }} <small>{{ contribute[locale].small }}</small></a></li>
 				<li><i class="fas fa-exclamation-circle fa-lg fa-fw" aria-hidden="true"></i><a{% if locale != en %} hreflang="en" {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/issues/new/choose">{{ contribute[locale].report }} <small>{{ contribute[locale].small }}</small></a></li>
 				<li><i class="fas fa-comments fa-lg fa-fw" aria-hidden="true"></i><a{% if locale != en %} hreflang="en" {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/discussions">{{ contribute[locale].join }} <small>{{ contribute[locale].small }}</small></a></li>
-			</ul>
-			<p>{{ contribute[locale].netlify }} <a{% if locale != en %} hreflang="en" {% endif %} href="https://www.netlify.com">Netlify</a></p>
+		</ul>
+		{% if settings.env == "dev" %}
+			<p>{{ contribute[locale].netlify }}
+				<a{% if locale != en %} hreflang="en" {% endif %} href="https://www.netlify.com">Netlify</a>
+			</p>
+		{% endif %}
 	</div>
 </aside>


### PR DESCRIPTION
This sets the `ELEVENTY_ENV=dev` on the Netlify instance so that the line of code needed for the Netlify membership is only visible on the development instances.

In the end removing "This site is powered by [Netlify](https://www.netlify.com/)" from the live site.

Already changed Netlify to run `npm run dev` when building.