### PR TITLE
Fixes to date modified value

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,16 +1,15 @@
 module.exports = function(eleventyConfig) {
-	const moment = require("moment");
+  const { DateTime } = require("luxon");
+
+  eleventyConfig.addFilter("postDate", (dateObj) => {
+    return DateTime.fromJSDate(dateObj, { zone: "utc" })
+      .setLocale("en")
+      .toFormat("yyyy'-'MM'-'dd");
+  });
 
 	eleventyConfig.addPassthroughCopy({ "./src/_docs" : "docs" });
 	eleventyConfig.addPassthroughCopy({ "./src/_images" : "img" });
 	eleventyConfig.addPassthroughCopy({ "./src/CNAME" : "CNAME" });
-
-	// date filter (localized)
-	eleventyConfig.addNunjucksFilter("date", function (date, format, locale) {
-		locale = locale ? locale : "en";
-		moment.locale(locale);
-		return moment(date).format(format);
-	});
 
 	return {
 			dir: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,10 @@
         "prompt-sync": "^4.2.0"
       },
       "devDependencies": {
-        "@11ty/eleventy": "^1.0.0",
+        "@11ty/eleventy": "^1.0.1",
         "@11ty/eleventy-navigation": "^0.3.3",
         "@cspell/dict-fr-fr": "^2.1.2",
         "cspell": "^6.18.1",
-        "moment": "^2.29.1",
         "npm-run-all": "^4.1.5",
         "sass": "^1.32.12"
       }
@@ -3616,15 +3615,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/moo": {
@@ -8819,12 +8809,6 @@
       "requires": {
         "minimist": "^1.2.6"
       }
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true
     },
     "moo": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
   },
   "homepage": "https://github.com/gc-da11yn/gc-da11yn.github.io#readme",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.0",
+    "@11ty/eleventy": "^1.0.1",
     "@11ty/eleventy-navigation": "^0.3.3",
     "@cspell/dict-fr-fr": "^2.1.2",
     "cspell": "^6.18.1",
-    "moment": "^2.29.1",
     "npm-run-all": "^4.1.5",
     "sass": "^1.32.12"
   },

--- a/src/_includes/partials/pagedetails.njk
+++ b/src/_includes/partials/pagedetails.njk
@@ -7,7 +7,7 @@
 	</div>
 	<dl id="wb-dtmd">
 		<dt>{{ pagedetails[locale].dateModified }}</dt>
-		<dd><time datetime="{{ post.date | date('YYYY-MM-DD') }}">{{ post.item|date("YYYY-MM-DD", locale) }}</time></dd>
+		<dd><time property="dateModified" datetime="{{ page.date | postDate }}">{{ page.date | postDate }}</time></dd>
 	</dl>
 </div>
 

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -1,3 +1,4 @@
 {
-	"locale" : "en"
+	"locale" : "en",
+  "date" : "git Last Modified"
 }

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -1,3 +1,4 @@
 {
-	"locale" : "fr"
+	"locale" : "fr",
+  "date" : "git Last Modified"
 }


### PR DESCRIPTION
- updates eleventy to 1.0.1
- switches to luxon instead of moment for date format
- removes moment npm package
- adds property to `time` element
- uses `git Last Modified` for date
- adds `date` to language folder json data files

This fixes an issue @fredymoko brought up in the developers meeting on Wednesday.