### PR TITLE
fix the links in the TOC navigation

### DIFF
--- a/src/en/guides/office2016/accessible-excel-documents.html
+++ b/src/en/guides/office2016/accessible-excel-documents.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible Excel documents
+title: Accessible Excel workbooks
 layout: layouts/base.njk
 description: Accessible practices for Microsoft Excel 2016 document creation.
 ---
@@ -8,9 +8,9 @@ description: Accessible practices for Microsoft Excel 2016 document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -145,6 +145,6 @@ description: Accessible practices for Microsoft Excel 2016 document creation.
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous"><a href="../accessible-powerpoint-documents" rel="prev">Previous: Accessible PowerPoint documents</a></li>
-	<li class="next"><a href="../accessible-visio-diagrams" rel="next">Next: Accessible Visio diagrams</a></li>
+	<li class="previous"><a href="../accessible-powerpoint-documents" rel="prev">Previous: Accessible PowerPoint presentations</a></li>
+	<li class="next"><a href="../accessible-visio-diagrams" rel="next">Next: Accessible Visio drawings</a></li>
 </ul>

--- a/src/en/guides/office2016/accessible-pdf-documents.html
+++ b/src/en/guides/office2016/accessible-pdf-documents.html
@@ -9,9 +9,9 @@ description: Accessible practices for PDF document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -155,5 +155,5 @@ description: Accessible practices for PDF document creation.
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous"><a href="../accessible-word-documents" rel="prev">Previous: Accessible Word documents</a></li>
-	<li class="next"><a href="../accessible-powerpoint-documents" rel="next">Next: Accessible PowerPoint documents</a></li>
+	<li class="next"><a href="../accessible-powerpoint-documents" rel="next">Next: Accessible PowerPoint presentations</a></li>
 </ul>

--- a/src/en/guides/office2016/accessible-powerpoint-documents.html
+++ b/src/en/guides/office2016/accessible-powerpoint-documents.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible PowerPoint documents
+title: Accessible PowerPoint presentations
 layout: layouts/base.njk
 description: Accessible practices for Microsoft PowerPoint 2016 document creation.
 ---
@@ -8,9 +8,9 @@ description: Accessible practices for Microsoft PowerPoint 2016 document creatio
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -200,5 +200,5 @@ description: Accessible practices for Microsoft PowerPoint 2016 document creatio
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous"><a href="../accessible-pdf-documents" rel="prev">Previous: Accessible PDF documents</a></li>
-	<li class="next"><a href="../accessible-excel-documents" rel="next">Next: Accessible Excel documents</a></li>
+	<li class="next"><a href="../accessible-excel-documents" rel="next">Next: Accessible Excel workbooks</a></li>
 </ul>

--- a/src/en/guides/office2016/accessible-visio-diagrams.html
+++ b/src/en/guides/office2016/accessible-visio-diagrams.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible Visio diagrams
+title: Accessible Visio drawings
 layout: layouts/base.njk
 description: Accessible practices for Microsoft Visio 2016 diagram creation.
 ---
@@ -9,9 +9,9 @@ description: Accessible practices for Microsoft Visio 2016 diagram creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -224,6 +224,6 @@ description: Accessible practices for Microsoft Visio 2016 diagram creation.
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous"><a href="../accessible-excel-documents" rel="prev">Previous: Accessible Excel documents</a></li>
+	<li class="previous"><a href="../accessible-excel-documents" rel="prev">Previous: Accessible Excel workbooks</a></li>
 	<li class="next disabled"><a href="../accessible-excel-documents" rel="next">Next:</a></li>
 </ul>

--- a/src/en/guides/office2016/accessible-word-documents.html
+++ b/src/en/guides/office2016/accessible-word-documents.html
@@ -9,9 +9,9 @@ description: Accessible practices for Microsoft Word 2016 document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 

--- a/src/en/guides/office2016/index.html
+++ b/src/en/guides/office2016/index.html
@@ -9,9 +9,9 @@ description: Accessible practices for digital document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-word-documents">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-pdf-documents">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 

--- a/src/en/guides/office365/accessible-excel-documents-365.html
+++ b/src/en/guides/office365/accessible-excel-documents-365.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible Excel documents
+title: Accessible Excel workbooks
 layout: layouts/base.njk
 description: Accessible practices for Microsoft Excel document creation.
 ---
@@ -9,9 +9,9 @@ description: Accessible practices for Microsoft Excel document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -132,6 +132,6 @@ description: Accessible practices for Microsoft Excel document creation.
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous"><a href="../accessible-powerpoint-documents-365" rel="prev">Previous: Accessible PowerPoint documents</a></li>
-	<li class="next"><a href="../accessible-visio-diagrams-365" rel="next">Next: Accessible Visio diagrams</a></li>
+	<li class="previous"><a href="../accessible-powerpoint-documents-365" rel="prev">Previous: Accessible PowerPoint presentations</a></li>
+	<li class="next"><a href="../accessible-visio-diagrams-365" rel="next">Next: Accessible Visio drawings</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-pdf-documents-365.html
+++ b/src/en/guides/office365/accessible-pdf-documents-365.html
@@ -9,9 +9,9 @@ description: Accessible practices for PDF document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -162,5 +162,5 @@ description: Accessible practices for PDF document creation.
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous"><a href="../accessible-word-documents-365" rel="prev">Previous: Accessible Word documents</a></li>
-	<li class="next"><a href="../accessible-powerpoint-documents-365" rel="next">Next: Accessible PowerPoint documents</a></li>
+	<li class="next"><a href="../accessible-powerpoint-documents-365" rel="next">Next: Accessible PowerPoint presentations</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-powerpoint-documents-365.html
+++ b/src/en/guides/office365/accessible-powerpoint-documents-365.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible PowerPoint documents
+title: Accessible PowerPoint presentations
 layout: layouts/base.njk
 description: Accessible practices for Microsoft PowerPoint document creation.
 ---
@@ -9,9 +9,9 @@ description: Accessible practices for Microsoft PowerPoint document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -367,5 +367,5 @@ description: Accessible practices for Microsoft PowerPoint document creation.
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous"><a href="../accessible-pdf-documents-365" rel="prev">Previous: Accessible PDF documents</a></li>
-	<li class="next"><a href="../accessible-excel-documents-365" rel="next">Next: Accessible Excel documents</a></li>
+	<li class="next"><a href="../accessible-excel-documents-365" rel="next">Next: Accessible Excel workbooks</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-visio-diagrams-365.html
+++ b/src/en/guides/office365/accessible-visio-diagrams-365.html
@@ -1,5 +1,5 @@
 ---
-title: Accessible Visio diagrams
+title: Accessible Visio drawings
 layout: layouts/base.njk
 description: Accessible practices for Microsoft Visio diagram creation.
 ---
@@ -9,9 +9,9 @@ description: Accessible practices for Microsoft Visio diagram creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 
@@ -248,6 +248,6 @@ description: Accessible practices for Microsoft Visio diagram creation.
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous"><a href="../accessible-excel-documents-365" rel="prev">Previous: Accessible Excel documents</a></li>
+	<li class="previous"><a href="../accessible-excel-documents-365" rel="prev">Previous: Accessible Excel workbooks</a></li>
 	<li class="next disabled"><a href="../accessible-excel-documents-365" rel="next">Next:</a></li>
 </ul>

--- a/src/en/guides/office365/accessible-word-documents-365.html
+++ b/src/en/guides/office365/accessible-word-documents-365.html
@@ -9,9 +9,9 @@ description: DESCRIPTION
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 

--- a/src/en/guides/office365/index.html
+++ b/src/en/guides/office365/index.html
@@ -9,9 +9,9 @@ description: Accessible practices for digital document creation.
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">1. How to create accessible documents</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-word-documents-365">2. Accessible Word documents</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-pdf-documents-365">3. Accessible PDF documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents-365">4. Accessible PowerPoint documents</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents-365">5. Accessible Excel documents</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams-365">6. Accessible Visio diagrams</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents-365">4. Accessible PowerPoint presentations</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents-365">5. Accessible Excel workbooks</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams-365">6. Accessible Visio drawings</a></li>
 	</ul>
 </div>
 

--- a/src/fr/guides/office2016/accessible-excel-documents.html
+++ b/src/fr/guides/office2016/accessible-excel-documents.html
@@ -1,17 +1,17 @@
 ---
-title: Documents Excel accessibles
+title: Classeurs Excel accessibles
 description: Pratiques accessibles pour la création de documents Microsoft Excel 2016.
 layout: layouts/base.njk
 ---
 
-<div class="row mrgn-tp-lg">
+<div class="row mrgn-tp-lg">"
 	<ul class="toc lst-spcd col-md-12">
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Présentation PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -116,6 +116,6 @@ layout: layouts/base.njk
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous small"><a href="../accessible-powerpoint-documents" rel="prev">Précédent : Documents PowerPoint accessibles</a></li>
-	<li class="next small"><a href="../accessible-visio-diagrams" rel="next">Suivant : Diagrammes Visio accessibles</a></li>
+	<li class="previous small"><a href="../accessible-powerpoint-documents" rel="prev">Précédent : Présentations PowerPoint accessibles</a></li>
+	<li class="next small"><a href="../accessible-visio-diagrams" rel="next">Suivant : Dessins Visio accessibles</a></li>
 </ul>

--- a/src/fr/guides/office2016/accessible-pdf-documents.html
+++ b/src/fr/guides/office2016/accessible-pdf-documents.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -150,5 +150,5 @@ layout: layouts/base.njk
 
 <ul class="pager mrgn-tp-xl">
 	<li class="previous small"><a href="../accessible-word-documents" rel="prev">Précédent : Documents Word accessibles</a></li>
-	<li class="next small"><a href="../accessible-powerpoint-documents" rel="next">Suivant : Documents PowerPoint accessibles</a></li>
+	<li class="next small"><a href="../accessible-powerpoint-documents" rel="next">Suivant : Présentations PowerPoint accessibles</a></li>
 </ul>

--- a/src/fr/guides/office2016/accessible-powerpoint-documents.html
+++ b/src/fr/guides/office2016/accessible-powerpoint-documents.html
@@ -1,5 +1,5 @@
 ---
-title: Documents PowerPoint accessibles
+title: Présentations PowerPoint accessibles
 description: Pratiques accessibles pour la création de documents Microsoft PowerPoint 2016.
 layout: layouts/base.njk
 ---
@@ -10,9 +10,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Directives relatives aux diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 

--- a/src/fr/guides/office2016/accessible-visio-diagrams.html
+++ b/src/fr/guides/office2016/accessible-visio-diagrams.html
@@ -1,5 +1,5 @@
 ---
-title: Diagrammes Visio accessibles
+title: Dessins Visio accessibles
 description: Pratiques accessibles pour la création de diagrammes Microsoft Visio 2016.
 layout: layouts/base.njk
 ---
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -147,6 +147,6 @@ layout: layouts/base.njk
 </ul>
 
 <ul class="pager mrgn-tp-xl">
-	<li class="previous small"><a href="../accessible-excel-documents" rel="prev">Précédent&nbsp;: Documents Excel accessibles</a></li>
+	<li class="previous small"><a href="../accessible-excel-documents" rel="prev">Précédent&nbsp;: Classeurs Excel accessibles</a></li>
 	<li class="next small disabled"><a href="../accessible-pdf-documents" rel="next">Suivant</a></li>
 </ul>

--- a/src/fr/guides/office2016/accessible-word-documents.html
+++ b/src/fr/guides/office2016/accessible-word-documents.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 

--- a/src/fr/guides/office2016/index.html
+++ b/src/fr/guides/office2016/index.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-word-documents">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-pdf-documents">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents">4. Documents PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents">4. Présentations PowerPoint accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-diagrams">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 

--- a/src/fr/guides/office365/accessible-excel-documents-365.html
+++ b/src/fr/guides/office365/accessible-excel-documents-365.html
@@ -1,5 +1,5 @@
 ---
-title: Documents Excel accessibles
+title: Classeurs Excel accessibles
 description: Pratiques accessibles pour la création de documents Microsoft Excel.
 layout: layouts/base.njk
 ---
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -103,6 +103,6 @@ layout: layouts/base.njk
 </ul>
 
 <ul class="pager">
-	<li class="previous small"><a href="../accessible-powerpoint-documents-365" rel="prev">Précédent : Documents PowerPoint accessibles</a></li>
-	<li class="next small"><a href="../accessible-visio-documents-365" rel="next">Suivant : Diagrammes Visio accessibles</a></li>
+	<li class="previous small"><a href="../accessible-powerpoint-documents-365" rel="prev">Précédent : Présentations PowerPoint accessibles</a></li>
+	<li class="next small"><a href="../accessible-visio-documents-365" rel="next">Suivant : Dessins Visio accessibles</a></li>
 </ul>

--- a/src/fr/guides/office365/accessible-pdf-documents-365.html
+++ b/src/fr/guides/office365/accessible-pdf-documents-365.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -157,5 +157,5 @@ layout: layouts/base.njk
 
 <ul class="pager">
 	<li class="previous small"><a href="../accessible-word-documents-365" rel="prev">Précédent : Documents Word accessibles</a></li>
-	<li class="next small"><a href="../accessible-powerpoint-documents-365" rel="next">Suivant : Documents PowerPoint accessibles</a></li>
+	<li class="next small"><a href="../accessible-powerpoint-documents-365" rel="next">Suivant : Présentations PowerPoint accessibles</a></li>
 </ul>

--- a/src/fr/guides/office365/accessible-powerpoint-documents-365.html
+++ b/src/fr/guides/office365/accessible-powerpoint-documents-365.html
@@ -1,5 +1,5 @@
 ---
-title: Documents PowerPoint accessibles
+title: Présentations PowerPoint accessibles
 description: Pratiques accessibles pour la création de documents Microsoft PowerPoint.
 layout: layouts/base.njk
 ---
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -219,5 +219,5 @@ layout: layouts/base.njk
 
 <ul class="pager">
 	<li class="previous small"><a href="../accessible-pdf-documents-365" rel="prev">Précédent : Documents PDF accessibles</a></li>
-	<li class="next small"><a href="../accessible-excel-documents-365" rel="next">Suivant : Documents Excel accessibles</a></li>
+	<li class="next small"><a href="../accessible-excel-documents-365" rel="next">Suivant : Classeurs Excel accessibles</a></li>
 </ul>

--- a/src/fr/guides/office365/accessible-visio-diagrams-365.html
+++ b/src/fr/guides/office365/accessible-visio-diagrams-365.html
@@ -1,5 +1,5 @@
 ---
-title: Diagrammes Visio accessibles
+title: Dessins Visio accessibles
 description: Pratiques accessibles pour la création de diagrammes Microsoft Visio.
 layout: layouts/base.njk
 ---
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-word-documents-365">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 
@@ -140,6 +140,6 @@ layout: layouts/base.njk
 </ul>
 
 <ul class="pager">
-	<li class="previous small"><a href="../accessible-excel-documents-365" rel="prev">Précédent&nbsp;: Documents Excel accessibles</a></li>
+	<li class="previous small"><a href="../accessible-excel-documents-365" rel="prev">Précédent&nbsp;: Classeurs Excel accessibles</a></li>
 	<li class="next small disabled"><a href="../accessible-pdf-documents-365" rel="next">Suivant</a></li>
 </ul>

--- a/src/fr/guides/office365/accessible-word-documents-365.html
+++ b/src/fr/guides/office365/accessible-word-documents-365.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-pdf-documents-365">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="../accessible-powerpoint-documents-365">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="../accessible-excel-documents-365">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="../accessible-visio-diagrams-365">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 

--- a/src/fr/guides/office365/index.html
+++ b/src/fr/guides/office365/index.html
@@ -9,9 +9,9 @@ layout: layouts/base.njk
 		<li class="col-md-4 col-sm-6"><a class="list-group-item active">1. Comment créer des documents accessibles</a></li>
 		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-word-documents-365">2. Documents Word accessibles</a></li>
 		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-pdf-documents-365">3. Documents PDF accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents-365">4. Documents PowerPoint accessibles</a></li>
-		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents-365">5. Documents Excel accessibles</a></li>
-		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-documents-365">6. Diagrammes Visio accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="./accessible-powerpoint-documents-365">4. Présentations PowerPoint accessibles</a></li>
+		<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="./accessible-excel-documents-365">5. Classeurs Excel accessibles</a></li>
+		<li class="col-md-4 col-sm-6"><a class="list-group-item" href="./accessible-visio-documents-365">6. Dessins Visio accessibles</a></li>
 	</ul>
 </div>
 


### PR DESCRIPTION
This PR is related to issue #275 and my old pull request 286. The "active" tag should be at the correct place and the other difference is that I change the title of the page in the footer menu so they are matching from top and bottom! 