### PR TITLE
update ubuntu to `latest` in github action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '12.x'
+          node-version: '19.x'
 
       - name: Reconfigure git to use HTTP authentication
         run: >


### PR DESCRIPTION
[The Ubuntu 18.04 Actions runner image will begin deprecation on 2022/08/08 and will be fully unsupported by 2023/04/03 · Issue #6002 · actions/runner-images](https://github.com/actions/runner-images/issues/6002)

Updated to to always use `latest` ubuntu image. 