### PR TITLE
remove deprecated redirects created for the restructure of the site

### DIFF
--- a/src/en/about/dat/index.md
+++ b/src/en/about/dat/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/digital-accessibility-toolkit-project/
-layout: layouts/base.njk
----

--- a/src/en/about/dat/terms-of-reference.md
+++ b/src/en/about/dat/terms-of-reference.md
@@ -1,4 +1,0 @@
----
-redirect: /en/terms-of-reference/
-layout: layouts/base.njk
----

--- a/src/en/about/index.md
+++ b/src/en/about/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/about-us/
-layout: layouts/base.njk
----

--- a/src/en/about/organizations/csps/index.md
+++ b/src/en/about/organizations/csps/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/canada-school-of-public-service-csps/
-layout: layouts/base.njk
----

--- a/src/en/about/organizations/esdc/index.md
+++ b/src/en/about/organizations/esdc/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/employment-and-social-development-canada-esdc/
-layout: layouts/base.njk
----

--- a/src/en/about/organizations/index.md
+++ b/src/en/about/organizations/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/about/organizations/statcan/index.md
+++ b/src/en/about/organizations/statcan/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/statistics-canada-statcan/
-layout: layouts/base.njk
----

--- a/src/en/about/workinggroups/awg/index.md
+++ b/src/en/about/workinggroups/awg/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/access-working-group-awg/
-layout: layouts/base.njk
----

--- a/src/en/about/workinggroups/index.md
+++ b/src/en/about/workinggroups/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/about/workinggroups/measurement/index.md
+++ b/src/en/about/workinggroups/measurement/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-desktop-software/a11ycheck-nonweb.md
+++ b/src/en/accessible-desktop-software/a11ycheck-nonweb.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/accessible-documents-questions-answers.md
+++ b/src/en/accessible-documents/accessible-documents-questions-answers.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/best-practices-excel.md
+++ b/src/en/accessible-documents/best-practices-excel.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/best-practices-outlook.md
+++ b/src/en/accessible-documents/best-practices-outlook.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/best-practices-powerpoint.md
+++ b/src/en/accessible-documents/best-practices-powerpoint.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/best-practices-word.md
+++ b/src/en/accessible-documents/best-practices-word.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/ms-doc-compliance-checklist.md
+++ b/src/en/accessible-documents/ms-doc-compliance-checklist.md
@@ -1,4 +1,0 @@
----
-redirect: /en/microsoft-document-compliance-checklist/
-layout: layouts/base.njk
----

--- a/src/en/accessible-documents/pdf-accessibility-checklist.md
+++ b/src/en/accessible-documents/pdf-accessibility-checklist.md
@@ -1,4 +1,0 @@
----
-redirect: /en/pdf-accessibility-checklist/
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/Official-languages-recommendations.md
+++ b/src/en/accessible-meetings/Official-languages-recommendations.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/accessible-meeting-event-guidelines.md
+++ b/src/en/accessible-meetings/accessible-meeting-event-guidelines.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/additional-resources.md
+++ b/src/en/accessible-meetings/additional-resources.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/index.md
+++ b/src/en/accessible-meetings/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/proposed-meeting-types-accessibility-features.md
+++ b/src/en/accessible-meetings/proposed-meeting-types-accessibility-features.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/accessible-meetings/virtual-meeting-platforms-accessibility-features.md
+++ b/src/en/accessible-meetings/virtual-meeting-platforms-accessibility-features.md
@@ -1,4 +1,0 @@
----
-redirect: en/virtual-meeting-platforms-and-accessibility-features/
-layout: layouts/base.njk
----

--- a/src/en/accessible-web-pages/a11ycheck.md
+++ b/src/en/accessible-web-pages/a11ycheck.md
@@ -1,4 +1,0 @@
----
-redirect: /en/web-accessibility-checklist/
-layout: layouts/base.njk
----

--- a/src/en/accessible-web-pages/wcag.md
+++ b/src/en/accessible-web-pages/wcag.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/bookmarks/index.md
+++ b/src/en/bookmarks/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/useful-links/
-layout: layouts/base.njk
----

--- a/src/en/common-types-of-disabilities/blindness.md
+++ b/src/en/common-types-of-disabilities/blindness.md
@@ -1,5 +1,0 @@
----
-redirect: /en/visual-impairments/#blindness
-layout: layouts/base.njk
----
-

--- a/src/en/common-types-of-disabilities/cognition.md
+++ b/src/en/common-types-of-disabilities/cognition.md
@@ -1,4 +1,0 @@
----
-redirect: /en/cognitive-disabilities/
-layout: layouts/base.njk
----

--- a/src/en/common-types-of-disabilities/deafness.md
+++ b/src/en/common-types-of-disabilities/deafness.md
@@ -1,4 +1,0 @@
----
-redirect: /en/auditory-disabilities/
-layout: layouts/base.njk
----

--- a/src/en/common-types-of-disabilities/index.md
+++ b/src/en/common-types-of-disabilities/index.md
@@ -1,4 +1,0 @@
----
-layout: layouts/base.njk
-redirect: /en/most-common-types-of-disability
----

--- a/src/en/common-types-of-disabilities/low-vision.md
+++ b/src/en/common-types-of-disabilities/low-vision.md
@@ -1,4 +1,0 @@
----
-redirect: /en/visual-impairments/#low-vision
-layout: layouts/base.njk
----

--- a/src/en/common-types-of-disabilities/mobility-dexterity.md
+++ b/src/en/common-types-of-disabilities/mobility-dexterity.md
@@ -1,4 +1,0 @@
----
-redirect: /en/mobility-flexibility-and-body-structure-disabilities/
-layout: layouts/base.njk
----

--- a/src/en/cra/index.md
+++ b/src/en/cra/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/a11ycheck-nonweb.html
+++ b/src/en/curriculum/a11ycheck-nonweb.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/desktop-application-developer.html
+++ b/src/en/curriculum/desktop-application-developer.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/desktop-application-tester.html
+++ b/src/en/curriculum/desktop-application-tester.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/index.html
+++ b/src/en/curriculum/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/web-application-developer.html
+++ b/src/en/curriculum/web-application-developer.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/web-application-tester.html
+++ b/src/en/curriculum/web-application-tester.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/curriculum/writers-editors-translators.html
+++ b/src/en/curriculum/writers-editors-translators.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -1,4 +1,0 @@
-{
-	"locale" : "en",
-  "date" : "git Last Modified"
-}

--- a/src/en/guides/design-accessible-services.html
+++ b/src/en/guides/design-accessible-services.html
@@ -1,4 +1,0 @@
----
-redirect: /en/designing-accessible-services
-layout: layouts/base.njk
----

--- a/src/en/guides/ict-requirements.html
+++ b/src/en/guides/ict-requirements.html
@@ -1,4 +1,0 @@
----
-redirect: /en/information-and-communications-technology-ict-accessibility-requirements
-layout: layouts/base.njk
----

--- a/src/en/guides/improving-form-accessibility.html
+++ b/src/en/guides/improving-form-accessibility.html
@@ -1,4 +1,0 @@
----
-redirect: /en/find-out-how-to-make-accessible-digital-forms
-layout: layouts/base.njk
----

--- a/src/en/guides/index.html
+++ b/src/en/guides/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/guides/mapping/index.md
+++ b/src/en/guides/mapping/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/mapping-between-revised-section-508-and-en-301-549-2014-2018-2019-and-2021
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/accessible-excel-documents.html
+++ b/src/en/guides/office2016/accessible-excel-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-excel-workbooks-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/accessible-pdf-documents.html
+++ b/src/en/guides/office2016/accessible-pdf-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-pdf-documents-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/accessible-powerpoint-documents.html
+++ b/src/en/guides/office2016/accessible-powerpoint-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-powerpoint-presentations-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/accessible-visio-diagrams.html
+++ b/src/en/guides/office2016/accessible-visio-diagrams.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-visio-drawings-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/accessible-word-documents.html
+++ b/src/en/guides/office2016/accessible-word-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-word-documents-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office2016/index.html
+++ b/src/en/guides/office2016/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/how-to-create-accessible-documents-in-office-2016
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/accessible-excel-documents-365.html
+++ b/src/en/guides/office365/accessible-excel-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-excel-workbooks-in-microsoft-365
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/accessible-pdf-documents-365.html
+++ b/src/en/guides/office365/accessible-pdf-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-pdf-documents-in-microsoft-365
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/accessible-powerpoint-documents-365.html
+++ b/src/en/guides/office365/accessible-powerpoint-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-powerpoint-presentations-in-microsoft-365
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/accessible-visio-diagrams-365.html
+++ b/src/en/guides/office365/accessible-visio-diagrams-365.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-visio-drawings-in-microsoft-365
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/accessible-word-documents-365.html
+++ b/src/en/guides/office365/accessible-word-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /en/accessible-word-documents-in-microsoft-365
-layout: layouts/base.njk
----

--- a/src/en/guides/office365/index.html
+++ b/src/en/guides/office365/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/how-to-create-accessible-documents-in-microsoft-365/
-layout: layouts/base.njk
----

--- a/src/en/guides/personas.html
+++ b/src/en/guides/personas.html
@@ -1,4 +1,0 @@
----
-redirect: /en/personas-with-disabilities-for-inclusive-user-experience-ux-design
-layout: layouts/base.njk
----

--- a/src/en/guides/virtual-meetings/index.html
+++ b/src/en/guides/virtual-meetings/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/best-practices-for-accessible-virtual-events/
-layout: layouts/base.njk
----

--- a/src/en/introduction/accessible-image.html
+++ b/src/en/introduction/accessible-image.html
@@ -1,4 +1,0 @@
----
-redirect: /en/designing-accessible-images/
-layout: layouts/base.njk
----

--- a/src/en/introduction/index.html
+++ b/src/en/introduction/index.html
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/standards/backgrounder.md
+++ b/src/en/standards/backgrounder.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/standards/index.md
+++ b/src/en/standards/index.md
@@ -1,4 +1,0 @@
----
-redirect: /en/targeted-engagement-draft-standard-on-information-and-communication-technology-ict-accessibility
-layout: layouts/base.njk
----

--- a/src/en/standards/standard.md
+++ b/src/en/standards/standard.md
@@ -1,4 +1,0 @@
----
-redirect: /en/page-moved-or-deleted/index.html
-layout: layouts/base.njk
----

--- a/src/en/standards/what_we_heard_report.md
+++ b/src/en/standards/what_we_heard_report.md
@@ -1,4 +1,0 @@
----
-redirect: /en/what-we-heard-report-standard-on-information-and-communication-technology-accessibility-sicta/
-layout: layouts/base.njk
----

--- a/src/fr/about/dat/index.md
+++ b/src/fr/about/dat/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/project-de-la-boite-a-outils-de-l-accessibilite-numerique/
-layout: layouts/base.njk
----

--- a/src/fr/about/dat/terms-of-reference.md
+++ b/src/fr/about/dat/terms-of-reference.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/mandats/
-layout: layouts/base.njk
----

--- a/src/fr/about/index.md
+++ b/src/fr/about/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/a-propos-de-nous/
-layout: layouts/base.njk
----

--- a/src/fr/about/organizations/csps/index.md
+++ b/src/fr/about/organizations/csps/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/ecole-de-la-fonction-publique-du-canada-efpc/
-layout: layouts/base.njk
----

--- a/src/fr/about/organizations/esdc/index.md
+++ b/src/fr/about/organizations/esdc/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/employment-and-social-development-canada-esdc/
-layout: layouts/base.njk
----

--- a/src/fr/about/organizations/index.md
+++ b/src/fr/about/organizations/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/about/organizations/statcan/index.md
+++ b/src/fr/about/organizations/statcan/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/statistique-canada-statcan/
-layout: layouts/base.njk
----

--- a/src/fr/about/workinggroups/awg/index.html
+++ b/src/fr/about/workinggroups/awg/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/le-groupe-de-travail-sur-l-acces-gta
-layout: layouts/base.njk
----

--- a/src/fr/about/workinggroups/index.md
+++ b/src/fr/about/workinggroups/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/about/workinggroups/measurement/index.html
+++ b/src/fr/about/workinggroups/measurement/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-desktop-software/a11ycheck-nonweb.md
+++ b/src/fr/accessible-desktop-software/a11ycheck-nonweb.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-desktop-software/index.md
+++ b/src/fr/accessible-desktop-software/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/accessible-documents-questions-answers.md
+++ b/src/fr/accessible-documents/accessible-documents-questions-answers.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/best-practices-excel.md
+++ b/src/fr/accessible-documents/best-practices-excel.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/best-practices-outlook.md
+++ b/src/fr/accessible-documents/best-practices-outlook.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/best-practices-powerpoint.md
+++ b/src/fr/accessible-documents/best-practices-powerpoint.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/best-practices-word.md
+++ b/src/fr/accessible-documents/best-practices-word.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/index.md
+++ b/src/fr/accessible-documents/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/ms-doc-compliance-checklist.md
+++ b/src/fr/accessible-documents/ms-doc-compliance-checklist.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/liste-de-verification-de-la-conformite-des-documents-microsoft/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-documents/pdf-accessibility-checklist.md
+++ b/src/fr/accessible-documents/pdf-accessibility-checklist.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/liste-de-verification-de-l-accessibilite-des-documents-pdf/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/Official-languages-recommendations.md
+++ b/src/fr/accessible-meetings/Official-languages-recommendations.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/accessible-meeting-event-guidelines.md
+++ b/src/fr/accessible-meetings/accessible-meeting-event-guidelines.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/additional-resources.md
+++ b/src/fr/accessible-meetings/additional-resources.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/index.md
+++ b/src/fr/accessible-meetings/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/reunions-evenements-virtuels-accessibles/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/proposed-meeting-types-accessibility-features.md
+++ b/src/fr/accessible-meetings/proposed-meeting-types-accessibility-features.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/accessible-meetings/virtual-meeting-platforms-accessibility-features.md
+++ b/src/fr/accessible-meetings/virtual-meeting-platforms-accessibility-features.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/plateformes-de-reunions-virtuelles-et-fonctionnalites/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-web-pages/a11ycheck.md
+++ b/src/fr/accessible-web-pages/a11ycheck.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/liste-de-verification-pour-l-accessibilite-web/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-web-pages/index.md
+++ b/src/fr/accessible-web-pages/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/pages-web-accessibles/
-layout: layouts/base.njk
----

--- a/src/fr/accessible-web-pages/wcag.md
+++ b/src/fr/accessible-web-pages/wcag.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/bookmarks/index.md
+++ b/src/fr/bookmarks/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/liens-utiles/
-layout: layouts/base.njk
----

--- a/src/fr/common-types-of-disabilities/blindness.md
+++ b/src/fr/common-types-of-disabilities/blindness.md
@@ -1,5 +1,0 @@
----
-redirect: /fr/deficiences-visuelles/#cécité
-layout: layouts/base.njk
----
-

--- a/src/fr/common-types-of-disabilities/cognition.md
+++ b/src/fr/common-types-of-disabilities/cognition.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/handicaps-cognitifs/
-layout: layouts/base.njk
----

--- a/src/fr/common-types-of-disabilities/deafness.md
+++ b/src/fr/common-types-of-disabilities/deafness.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/deficiences-auditives/
-layout: layouts/base.njk
----

--- a/src/fr/common-types-of-disabilities/index.md
+++ b/src/fr/common-types-of-disabilities/index.md
@@ -1,4 +1,0 @@
----
-layout: layouts/base.njk
-redirect: /fr/types-de-handicap-les-plus-courants/
----

--- a/src/fr/common-types-of-disabilities/low-vision.md
+++ b/src/fr/common-types-of-disabilities/low-vision.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/deficiences-visuelles/#basse-vision
-layout: layouts/base.njk
----

--- a/src/fr/common-types-of-disabilities/mobility-dexterity.md
+++ b/src/fr/common-types-of-disabilities/mobility-dexterity.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/handicaps-de-mobilite-de-flexibilite-et-de-structure-corporelle/
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/a11ycheck-nonweb.html
+++ b/src/fr/curriculum/a11ycheck-nonweb.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/desktop-application-developer.html
+++ b/src/fr/curriculum/desktop-application-developer.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/desktop-application-tester.html
+++ b/src/fr/curriculum/desktop-application-tester.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/index.html
+++ b/src/fr/curriculum/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/web-application-developer.html
+++ b/src/fr/curriculum/web-application-developer.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/web-application-tester.html
+++ b/src/fr/curriculum/web-application-tester.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/curriculum/writers-editors-translators.html
+++ b/src/fr/curriculum/writers-editors-translators.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -1,4 +1,0 @@
-{
-	"locale" : "fr",
-  "date" : "git Last Modified"
-}

--- a/src/fr/guides/design-accessible-services.html
+++ b/src/fr/guides/design-accessible-services.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/principes-de-conception-pour-des-services-accessibles
-layout: layouts/base.njk
----

--- a/src/fr/guides/ict-requirements.html
+++ b/src/fr/guides/ict-requirements.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/exigences-en-matiere-de-technologies-de-l-information-et-des-communications-tic-accessibles
-layout: layouts/base.njk
----

--- a/src/fr/guides/improving-form-accessibility.html
+++ b/src/fr/guides/improving-form-accessibility.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/ameliorer-l-accessibilite-des-formulaires
-layout: layouts/base.njk
----

--- a/src/fr/guides/index.html
+++ b/src/fr/guides/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/guides/mapping/index.md
+++ b/src/fr/guides/mapping/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/mise-en-correspondance-entre-l-article-508-revise-revised-section-508-et-la-norme-en-301-549-2014-2018-2019-et-2021
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/accessible-excel-documents.html
+++ b/src/fr/guides/office2016/accessible-excel-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/classeurs-excel-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/accessible-pdf-documents.html
+++ b/src/fr/guides/office2016/accessible-pdf-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/documents-pdf-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/accessible-powerpoint-documents.html
+++ b/src/fr/guides/office2016/accessible-powerpoint-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/presentations-powerpoint-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/accessible-visio-diagrams.html
+++ b/src/fr/guides/office2016/accessible-visio-diagrams.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/dessins-visio-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/accessible-word-documents.html
+++ b/src/fr/guides/office2016/accessible-word-documents.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/documents-word-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office2016/index.html
+++ b/src/fr/guides/office2016/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/comment-creer-des-documents-accessibles-dans-office-2016
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/accessible-excel-documents-365.html
+++ b/src/fr/guides/office365/accessible-excel-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/classeurs-excel-accessibles-dans-microsoft-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/accessible-pdf-documents-365.html
+++ b/src/fr/guides/office365/accessible-pdf-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/documents-pdf-accessibles-dans-microsoft-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/accessible-powerpoint-documents-365.html
+++ b/src/fr/guides/office365/accessible-powerpoint-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/presentations-powerpoint-accessibles-dans-microsoft-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/accessible-visio-diagrams-365.html
+++ b/src/fr/guides/office365/accessible-visio-diagrams-365.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/dessins-visio-accessibles-dans-microsoft-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/accessible-word-documents-365.html
+++ b/src/fr/guides/office365/accessible-word-documents-365.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/documents-word-accessibles-dans-microsoft-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/office365/index.html
+++ b/src/fr/guides/office365/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/comment-creer-des-documents-accessibles-dans-office-365
-layout: layouts/base.njk
----

--- a/src/fr/guides/personas.html
+++ b/src/fr/guides/personas.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/personas-handicapes-pour-la-conception-d-une-experience-utilisateur-inclusive-eu
-layout: layouts/base.njk
----

--- a/src/fr/guides/virtual-meetings/index.html
+++ b/src/fr/guides/virtual-meetings/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/bonnes-pratiques-pour-les-evenements-virtuels-accessibles/
-layout: layouts/base.njk
----

--- a/src/fr/introduction/accessible-image.html
+++ b/src/fr/introduction/accessible-image.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/concevoir-des-images-accessibles
-layout: layouts/base.njk
----

--- a/src/fr/introduction/index.html
+++ b/src/fr/introduction/index.html
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/standards/backgrounder.md
+++ b/src/fr/standards/backgrounder.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/standards/index.md
+++ b/src/fr/standards/index.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/seance-de-mobilisation-ciblee-lebauche-de-la-norme-daccessibilite-des-technologies-de-linformation-et-des-communications-tic/
-layout: layouts/base.njk
----

--- a/src/fr/standards/standard.md
+++ b/src/fr/standards/standard.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/page-deplacee-ou-supprimee/index.html
-layout: layouts/base.njk
----

--- a/src/fr/standards/what_we_heard_report.md
+++ b/src/fr/standards/what_we_heard_report.md
@@ -1,4 +1,0 @@
----
-redirect: /fr/rapport-sur-ce-que-nous-avons-entendu-norme-d-accessibilite-des-technologies-de-l-information-et-des-communications-natic/
-layout: layouts/base.njk
----


### PR DESCRIPTION
Removing all the redirects we put in for the old pages from December. One less thing to maintain. Our 404 page has a link to the filtered page list which makes finding a page that was moved easy.