### PR TITLE
Changed all links, added titles and re-organized the list in both EN and FR

### DIFF
--- a/src/pages/en/microsoft-document-compliance-checklist.md
+++ b/src/pages/en/microsoft-document-compliance-checklist.md
@@ -37,16 +37,15 @@ If you answer ‘No’ to one of the following questions, then your document IS 
 ## General
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are document Properties filled out properly (title, author, subject)? (2.4.2)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the language of the document properly set? (3.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Did the document fully pass the Accessibility Checker? (4.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from content such as comments, track changes, and highlight? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the order of the content accurate and logical (instructions or introduction first)? (1.3.2)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from electronically fillable forms? (3.3.2)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Can all the text be resized and still be considered readable when magnified to 200%? (1.4.4)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are document Properties filled out properly (title, author, subject)? (<a href="https://www.w3.org/TR/WCAG22/#page-titled">2.4.2: Page Titled</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the language of the document properly set? (<a href="https://www.w3.org/TR/WCAG22/#language-of-page">3.1.1: Language of Page</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from content such as comments, track changes, and highlight? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the order of the content accurate and logical (instructions or introduction first)? (<a href="https://www.w3.org/TR/WCAG22/#meaningful-sequence">1.3.2: Meaningful Sequence</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from electronically fillable forms? (<a href="https://www.w3.org/TR/WCAG22/#labels-or-instructions">3.3.2: Labels or Instructions</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Can all the text be resized and still be considered readable when magnified to 200%? (<a href="https://www.w3.org/TR/WCAG22/#resize-text">1.4.4: Resize Text</a>)</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the readability grade level meet the target audience: up to grade 8 for public audience and up to grade 10 for internal to ESDC?</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all acronyms provided in full words (or spelled out) the first time they are used in the document? (3.1.4)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the spacing between lines of text a minimum of 1.5? (1.4.12)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all acronyms provided in full words (or spelled out) the first time they are used in the document? (<a href="https://www.w3.org/TR/WCAG22/#abbreviations">3.1.4: Abbreviations</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the spacing between lines of text a minimum of 1.5? (<a href="https://www.w3.org/TR/WCAG22/#text-spacing">1.4.12: Text Spacing</a>)</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the text free of any tabs or spaces to align or centre the text? Use the feature indent and spacing of the paragraph instead.</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the text aligned left or right, and never justified (aligned on both sides)?</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the text free of empty new lines or hard returns to create space between the paragraphs? Use page break or before and after paragraph option instead.</li>
@@ -58,63 +57,63 @@ If you answer ‘No’ to one of the following questions, then your document IS 
 ## Colour
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does any information conveyed with color have a non-color method for understanding (is the information available when you remove the colors)? (1.4.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all non-text objects like graphs or drawings (with the exception of logos and photographs) have a contrast ratio of 3:1 or greater? (1.4.3)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does any information conveyed with color have a non-color method for understanding (is the information available when you remove the colors)? (<a href="https://www.w3.org/TR/WCAG22/#use-of-color">1.4.1: Use of Color</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all non-text objects like graphs or drawings (with the exception of logos and photographs) have a contrast ratio of 3:1 or greater? (<a href="https://www.w3.org/TR/WCAG22/#contrast-minimum">1.4.3: Contrast (Minimum)</a>)</li>
 </ul>
 
 ## Links
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are links identified using the Hyperlink paragraph style? (1.4.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do hyperlinks provide link text that identifies the purpose of the link without needing additional context? (2.4.4)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does generic link text have sufficient context (not using the words Link or click here)? (2.4.4)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are links identified using the Hyperlink paragraph style? (<a href="https://www.w3.org/TR/WCAG22/#use-of-color">1.4.1: Use of Color</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do hyperlinks provide link text that identifies the purpose of the link without needing additional context? (<a href="https://www.w3.org/TR/WCAG22/#link-purpose-in-context">2.4.4: Link Purpose</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does generic link text have sufficient context (not using the words Link or click here)? (<a href="https://www.w3.org/TR/WCAG22/#link-purpose-in-context">2.4.4: Link Purpose (In Context)</a>)</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all links properly linked (no broken links)?</li>
 </ul>
 
 ## Images
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all informational images have alt text that provides the same level of understanding a visual user would gain? (1.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all decorative images marked decorative (containing “ ” or the word “decorative” in the alt text field)? (1.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are multi-layered objects grouped into one object and appropriate alternative text applied, if required? (1.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do complex informational (not decorative) images have an alternate accessible means of understanding (usually a long description or caption)? (1.1.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from any content that should not be included as an image? (Picture of a table with text, image of text) (1.4.5)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from content that flashes more than 3 times per second? (2.3.1)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all informational images have alt text that provides the same level of understanding a visual user would gain? (<a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1: Non-text Content</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all decorative images marked decorative (containing “ ” or the word “decorative” in the alt text field)? (<a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1: Non-text Content</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are multi-layered objects grouped into one object and appropriate alternative text applied, if required? (<a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1: Non-text Content</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do complex informational (not decorative) images have an alternate accessible means of understanding (usually a long description or caption)? (<a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1: Non-text Content</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from any content that should not be included as an image? (Picture of a table with text, image of text) (<a href="https://www.w3.org/TR/WCAG22/#images-of-text">1.4.5: Images of Text</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from content that flashes more than 3 times per second? (<a href="https://www.w3.org/TR/WCAG22/#three-flashes-or-below-threshold">2.3.1: Three Flashes or Below Threshold</a>)</li>
 </ul>
 
 ## Tables
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Were tables created with the built in table styles (not with spaces or indent)? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the table structure match the visual table layout (simple layout structure – no merged or split cells)? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all tables have defined header row(s) and/or header column(s)? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from tables used for content that is not a data (tables used for layout only)? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from data tables with merged cells, both column and row header cells? (1.3.1)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Were tables created with the built in table styles (not with spaces or indent)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the table structure match the visual table layout (simple layout structure – no merged or split cells)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do all tables have defined header row(s) and/or header column(s)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from tables used for content that is not a data (tables used for layout only)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the document free from data tables with merged cells, both column and row header cells? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
 </ul>
 
 ## Lists
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the document contain only lists built with list styles? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are multiple lists in the same document properly organized (grouped or at levels)? (1.3.1)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the document contain only lists built with list styles? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are multiple lists in the same document properly organized (grouped or at levels)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
 </ul>
 
 ## Headings
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is all text that acts as a visual heading marked with the proper heading style? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do headings follow a logical hierarchical progression? (for example, H1-H2-H3) (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all the headings visually modified via the heading style? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the heading text accurately describe the following content? (2.4.6)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the document contain a heading style for each section? (2.4.6)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is all text that acts as a visual heading marked with the proper heading style? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Do headings follow a logical hierarchical progression? (for example, H1-H2-H3) (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are all the headings visually modified via the heading style? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the heading text accurately describe the following content? (<a href="https://www.w3.org/TR/WCAG22/#headings-and-labels">2.4.6: Headings and Labels</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the document contain a heading style for each section? (<a href="https://www.w3.org/TR/WCAG22/#headings-and-labels">2.4.6: Headings and Labels</a>)</li>
     <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Does the Navigation pane from the View menu show all the headings, and nothing more (including no empty lines)?</li>
 </ul>
 
 ## Other elements
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the table of contents (TOC) generated with the built in office styles? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are citations and footnotes/endnotes created with the built in office styles? (1.3.1)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the language properly set for the corresponding language of words or phrases? (3.1.2)</li>
-    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is information in the header, footer, watermark, speaker notes, etc. available in the main body of the document (except page numbering)? (1.3.1)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the table of contents (TOC) generated with the built in office styles? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Are citations and footnotes/endnotes created with the built in office styles? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is the language properly set for the corresponding language of words or phrases? (<a href="https://www.w3.org/TR/WCAG22/#language-of-parts">3.1.2: Language of Parts</a>)</li>
+    <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Is information in the header, footer, watermark, speaker notes, etc. available in the main body of the document (except page numbering)? (<a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1: Info and Relationships</a>)</li>
 </ul>

--- a/src/pages/fr/liste-de-verification-de-la-conformite-des-documents-microsoft.md
+++ b/src/pages/fr/liste-de-verification-de-la-conformite-des-documents-microsoft.md
@@ -37,16 +37,15 @@ Si vous répondez « Non » à l’une des questions suivantes, votre document N
 ## Renseignements d’ordre général
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les propriétés du document sont-elles remplies de manière conforme (titre, auteur, sujet) ? (2.4.2)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La langue du document est-elle bien définie ? (3.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il déclaré conforme selon le Vérificateur de l’accessibilité ? (4.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il libre de commentaires, de suivi des modifications et de surligne ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L’ordre de présentation du contenu est-il exact et logique?  (1.3.2)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de formulaires électroniques à remplir ? (3.3.2)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-il possible de redimensionner l’ensemble du texte et demeure-t-il lisible lorsqu’il est grossi à 200 % ? (1.4.4)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les propriétés du document sont-elles remplies de manière conforme (titre, auteur, sujet) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#page-titled">2.4.2 : Titre de page</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La langue du document est-elle bien définie ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#language-of-page">3.1.1 : Langue de la page</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il libre de commentaires, de suivi des modifications et de surligne ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L’ordre de présentation du contenu est-il exact et logique? (<a href="https://www.w3.org/Translations/WCAG21-fr/#meaningful-sequence">1.3.2 : Ordre séquentiel logique</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de formulaires électroniques à remplir ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#labels-or-instructions">3.3.2 : Étiquettes ou instructions</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-il possible de redimensionner l’ensemble du texte et demeure-t-il lisible lorsqu’il est grossi à 200 % ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#resize-text">1.4.4 : Redimensionnement du texte</a>)</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le niveau de lisibilité est-il compatible avec le public cible: maximum grade 8 pour publique générale et maximum grade 10 à l'interne de EDSC ?</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les acronymes sont-ils définis dès qu’ils sont mentionnés la première fois dans le document ? (3.1.4)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L'espacement de contenu textuel est-il d'au moins 1.5 (interligne) ? (1.4.12)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les acronymes sont-ils définis dès qu’ils sont mentionnés la première fois dans le document ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#abbreviations">3.1.4 : Abréviations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L'espacement de contenu textuel est-il d'au moins 1.5 (interligne) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#text-spacing">1.4.12 : Espacement du texte</a>)</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte est-il exempt de tabulations ou d’espaces pour aligner ou centrer le texte ? Utilisez plutôt le retrait et l’espacement des caractéristiques du paragraphe.</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte est-il aligné à gauche ou à droite, et n’est-il jamais justifié (aligné des deux côtés) ?</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte est-il exempt de nouvelles lignes vides ou de retours forcés pour créer de l’espace entre les paragraphes ? Utilisez plutôt l’option de saut de page ou l’option de paragraphe avant et après.</li>
@@ -58,55 +57,55 @@ Si vous répondez « Non » à l’une des questions suivantes, votre document N
 ## Couleur
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-ce que tous les objets (tableaux et graphiques) de couleur sont assortis d’une méthode qui ne repose pas sur les couleurs pour assurer a compréhension (utilisation de figures ou *) ? (1.4.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les objets non textuels tels que les graphiques ou les dessins (à l’exception des logos et des photographies) ont-ils un rapport de contraste de 3:1 ou plus ? (1.4.3)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-ce que tous les objets (tableaux et graphiques) de couleur sont assortis d’une méthode qui ne repose pas sur les couleurs pour assurer a compréhension (utilisation de figures ou *) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#use-of-color">1.4.1 : Utilisation de la couleur</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les objets non textuels tels que les graphiques ou les dessins (à l’exception des logos et des photographies) ont-ils un rapport de contraste de 3:1 ou plus ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#contrast-minimum">1.4.3 : Contraste (minimum)</a>)</li>
 </ul>
 
 ## Liens
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les liens sont-ils identifiés à l’aide du style de paragraphe de lien hypertexte ? (1.4.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les hyperliens fournissent-ils un texte de lien qui identifie l’objectif du lien sans avoir besoin de contexte supplémentaire ? (2.4.4)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte générique des liens est-il suffisamment contextuel? (Vous n’utilisez pas le mot Lien ou la formule cliquez ici) ? (2.4.4)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les liens sont-ils identifiés à l’aide du style de paragraphe de lien hypertexte ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#use-of-color">1.4.1 : Utilisation de la couleur</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les hyperliens fournissent-ils un texte de lien qui identifie l’objectif du lien sans avoir besoin de contexte supplémentaire ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#link-purpose-in-context">2.4.4 : Fonction du lien</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte générique des liens est-il suffisamment contextuel? (Vous n’utilisez pas le mot Lien ou la formule cliquez ici) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#link-purpose-in-context">2.4.4 : Fonction du lien (selon le contexte)</a>)</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Tous les liens sont-ils correctement liés (pas de liens brisés) ?</li>
 </ul>
 
 ## Images
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Toutes les images contenant de l’information comportent-elles du texte de remplacement qui fournit le même niveau de compréhension qu’un utilisateur visuel obtiendrait ? (1.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Toutes les images décoratives sont-elles marquées décoratives (contenant " " ou le mot « décoratif » dans le champ de texte alternatif) ? (1.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les objets multicouches sont-ils regroupés en un seul objet ou aplanis) et un texte de remplacement approprié est-il appliqué, si nécessaire ? (1.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les images d’information complexes (non décoratives) sont-elles assorties d’un autre moyen de compréhension (habituellement une longue description) ? (1.1.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tout contenu qui ne devrait pas être inclus comme image ? (Image d’un tableau avec texte, image de texte) (1.4.5)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de contenu qui clignote plus de 3 fois par seconde ? (2.3.1)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Toutes les images contenant de l’information comportent-elles du texte de remplacement qui fournit le même niveau de compréhension qu’un utilisateur visuel obtiendrait ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#non-text-content">1.1.1 : Contenu non textuel</a>)(1.1.1)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Toutes les images décoratives sont-elles marquées décoratives (contenant " " ou le mot « décoratif » dans le champ de texte alternatif) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#non-text-content">1.1.1 : Contenu non textuel</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les objets multicouches sont-ils regroupés en un seul objet ou aplanis et un texte de remplacement approprié est-il appliqué, si nécessaire ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#non-text-content">1.1.1 : Contenu non textuel</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les images d’information complexes (non décoratives) sont-elles assorties d’un autre moyen de compréhension (habituellement une longue description) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#non-text-content">1.1.1 : Contenu non textuel</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tout contenu qui ne devrait pas être inclus comme image ? (Image d’un tableau avec texte, image de texte) (<a href="https://www.w3.org/Translations/WCAG21-fr/#images-of-text">1.4.5 : Texte sous forme d’image</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de contenu qui clignote plus de 3 fois par seconde ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#three-flashes-or-below-threshold">2.3.1 : Pas plus de trois flashs ou sous le seuil critique</a>)</li>
 </ul>
 
 ## Tableaux
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le tableau a-t-il été créé à l’aide des styles de tableau intégrés (et non avec des espaces ou des tabulations) ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La structure du tableau correspond-elle à la disposition visuelle du tableau (structure simple de disposition – aucune cellule fusionnée ou fractionnée) ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>•	Toutes les tables ont-elles des lignes d’en-tête et/ou des colonnes d’en-tête définies ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tableaux utilisés pour du contenu qui n’est pas une donnée (tableaux utilisés pour la mise en page seulement) ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tableaux de données contenant des cellules fusionnées, cellules d’en-tête de ligne et de colonne ? (1.3.1)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le tableau a-t-il été créé à l’aide des styles de tableau intégrés (et non avec des espaces ou des tabulations) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La structure du tableau correspond-elle à la disposition visuelle du tableau (structure simple de disposition – aucune cellule fusionnée ou fractionnée) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>•	Toutes les tables ont-elles des lignes d’en-tête et/ou des colonnes d’en-tête définies ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tableaux utilisés pour du contenu qui n’est pas une donnée (tableaux utilisés pour la mise en page seulement) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document est-il exempt de tableaux de données contenant des cellules fusionnées, cellules d’en-tête de ligne et de colonne ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
 </ul>
 
 ## Listes
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document contient-il uniquement des listes créées avec des styles de liste ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les listes multiples d’un même document sont-elles bien organisées (regroupées ou à divers niveaux) ? (1.3.1)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document contient-il uniquement des listes créées avec des styles de liste ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les listes multiples d’un même document sont-elles bien organisées (regroupées ou à divers niveaux) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
 </ul>
 
 ## En-têtes
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-ce que tout le texte qui sert d’en-tête visuel est marqué par le style d’en-tête approprié ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les titres suivent-ils une progression hiérarchique logique? (H1-H2-H3) (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les changements apportés au style des titres ont-ils été effectués moyen de la fonction « modifier le style de l’en-tête » ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte de l’en-tête décrit-il correctement le contenu suivant ? (2.4.6)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document contient-il un style d’en-tête pour chaque section identifiée ? (2.4.6)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Est-ce que tout le texte qui sert d’en-tête visuel est marqué par le style d’en-tête approprié ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les titres suivent-ils une progression hiérarchique logique? (H1-H2-H3) (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les changements apportés au style des titres ont-ils été effectués moyen de la fonction « modifier le style de l’en-tête » ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le texte de l’en-tête décrit-il correctement le contenu suivant ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#headings-and-labels">2.4.6 : En-têtes et étiquettes</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le document contient-il un style d’en-tête pour chaque section identifiée ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#headings-and-labels">2.4.6 : En-têtes et étiquettes</a>)</li>
 <li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Le volet de navigation du menu Affichage affiche-t-il tous les en-têtes, et rien de plus (y compris aucune ligne vide) ?</li>
 </ul>
 </ul>
@@ -114,8 +113,8 @@ Si vous répondez « Non » à l’une des questions suivantes, votre document N
 ## Autres éléments
 
 <ul class="list-unstyled mrgn-tp-lg mrgn-lft-lg">
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La table des matières est-elle produite à l’aide des styles Office intégrés ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les citations et les notes de bas de page/notes de fin de document sont-elles créées à l’aide des styles Office intégrés ? (1.3.1)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La langue est-elle correctement réglée pour la langue correspondante des mots ou des phrases ? (3.1.2)</li>
-<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L’information contenue l’en-tête, le pied de page, le filigrane, les notes du conférencier, etc. est-elle disponible dans le corps principal du document (sauf la numérotation des pages) ? (1.3.1)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La table des matières est-elle produite à l’aide des styles Office intégrés ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>Les citations et les notes de bas de page/notes de fin de document sont-elles créées à l’aide des styles Office intégrés ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>La langue est-elle correctement réglée pour la langue correspondante des mots ou des phrases ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#language-of-parts">3.1.2 : Langue d’un passage</a>)</li>
+<li class="mrgn-bttm-md"><span class="far fa-square mrgn-rght-md" aria-hidden="true"></span>L’information contenue l’en-tête, le pied de page, le filigrane, les notes du conférencier, etc. est-elle disponible dans le corps principal du document (sauf la numérotation des pages) ? (<a href="https://www.w3.org/Translations/WCAG21-fr/#info-and-relationships">1.3.1 : Information et relations</a>)</li>
 </ul>


### PR DESCRIPTION
Changed all links, added titles and re-organized the list in both EN and FR pages at @Syracopoulos's & @shawnthompson's requests.

Removed "**Did the document fully pass the Accessibility Checker? (4.1.1: Rules for the Accessibility Checker**)" from EN file and "**Le document est-il déclaré conforme selon le Vérificateur de l’accessibilité ? (4.1.1 : Analyse syntaxique)**" from FR file due to lack of WCAG 2.2 translation.

Will update once official translation is out from WCAG for WCAG 2.0.

Close #628 

@netlify /en/pages-to-review/