### PR TITLE
Fix #667: Update header grammar on How-to page

### DIFF
--- a/src/main/en/how-tos/index.njk
+++ b/src/main/en/how-tos/index.njk
@@ -1,6 +1,6 @@
 ---
-title: How to’s
-description: Tips and core steps to help make all your digital products and content, such as documents, meetings, accessible.
+title: How-tos
+description: Tips and core steps to help make all your digital products and content, such as documents and meetings, accessible.
 toggle: comment-faire
 tags:
   - main


### PR DESCRIPTION
Do not delete the following line

@netlify /en/pages-to-review/

<div lang="fr">

([Français](#Français))

</div>

## What does this pull request (PR) do?

- Fixed issue #667 opened by [@lindseykeene](https://github.com/lindseykeene).
- Changed section title from "How to's" to "How-tos".
- Updated subhead to add the missing "and" between "documents" and "meetings" and removed the comma.

### General checklist

- [x] Create/update documentation
- [x] Build and test PR's code
- [x] Validate changes against WCAG for accessibility
- [x] Ensure documentation is bilingual

### Related issues

#667
