### PR TITLE
Remove depth option from upstream fetch command in Eleventy config

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -239,7 +239,7 @@ module.exports = function (eleventyConfig) {
     const upstreamUrl = 'https://github.com/gc-da11yn/gc-da11yn.github.io';
 
     try {
-      execSync(`git fetch ${upstreamUrl} main:upstream-main --force --depth=1`);
+      execSync(`git fetch ${upstreamUrl} main:upstream-main --force`);
     } catch (err) {
       console.error('Error fetching the upstream main branch', err);
     }


### PR DESCRIPTION
Do not delete the following line

@netlify /en/pages-to-review/

`git fetch ${upstreamUrl} main:upstream-main --force --depth=1` is added to the config to help list the new updated pages in the terminal by comparing the main branch upstream to the current local files and listing the files that are different. 

By setting `--depth=1` it would mark all the files with the current date as if they were just committed.

Removed it so the real `git Last Modified` date would be used on the pages.