### PR TITLE
Add Sa11y to dev environment

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -71,6 +71,7 @@
 		</script>
 		<script src="/js/chart.js"></script>
 		{%- endif -%}
+    {% include "partials/sa11y.njk" %}
 	</body>
 
 </html>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -71,7 +71,9 @@
 		</script>
 		<script src="/js/chart.js"></script>
 		{%- endif -%}
+{%- if settings.env == "dev" or settings.env == "local" -%}
     {% include "partials/sa11y.njk" %}
+{%- endif -%}
 	</body>
 
 </html>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -44,6 +44,7 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js"></script>
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+  {% include "partials/sa11y.njk" %}
 </body>
 </html>
 

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -44,7 +44,9 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js"></script>
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-  {% include "partials/sa11y.njk" %}
+{%- if settings.env == "dev" or settings.env == "local" -%}
+    {% include "partials/sa11y.njk" %}
+{%- endif -%}
 </body>
 </html>
 

--- a/src/_includes/partials/sa11y.njk
+++ b/src/_includes/partials/sa11y.njk
@@ -1,0 +1,24 @@
+{#
+  Sa11y, the accessibility quality assurance assistant.
+  Project website: https://sa11y.netlify.app
+
+  This code block checks if the environment is set to "dev". If it is, it displays Sa11y in the bottom right corner.
+  The code is served from the jsDelivr CDN.
+
+  - To update Sa11y, grab the latest release tag from https://github.com/ryersondmp/sa11y/releases
+  - To customize, refer to props: https://sa11y.netlify.app/developers/props/
+ #}
+
+{% set sa11yVersion = "4.0.9" %}
+
+{% if settings.env == "dev" %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/css/sa11y.min.css"/>
+<script src="https://cdn.jsdelivr.net/combine/gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/js/lang/{{locale}}.umd.js,gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/js/sa11y.umd.min.js"></script>
+<script>
+Sa11y.Lang.addI18n(Sa11yLang{{ locale | capitalize }}.strings);
+const sa11y = new Sa11y.Sa11y({
+  checkRoot: "body",
+  developerChecksOnByDefault: true,
+});
+</script>
+{% endif %}

--- a/src/_includes/partials/sa11y.njk
+++ b/src/_includes/partials/sa11y.njk
@@ -11,7 +11,6 @@
 
 {% set sa11yVersion = "4.1.0" %}
 
-{% if settings.env == "dev" %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/css/sa11y.min.css"/>
 <script src="https://cdn.jsdelivr.net/combine/gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/js/lang/{{locale}}.umd.js,gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/js/sa11y.umd.min.js"></script>
 <script>
@@ -21,4 +20,3 @@ const sa11y = new Sa11y.Sa11y({
   developerChecksOnByDefault: true,
 });
 </script>
-{% endif %}

--- a/src/_includes/partials/sa11y.njk
+++ b/src/_includes/partials/sa11y.njk
@@ -18,5 +18,8 @@ Sa11y.Lang.addI18n(Sa11yLang{{ locale | capitalize }}.strings);
 const sa11y = new Sa11y.Sa11y({
   checkRoot: "body",
   developerChecksOnByDefault: true,
+  contrastIgnore: '.gc-main-footer',
+  imageIgnore: 'img[src*="sig-blk-en.svg"]',
+  containerIgnore: '#wb-srch-q',
 });
 </script>

--- a/src/_includes/partials/sa11y.njk
+++ b/src/_includes/partials/sa11y.njk
@@ -9,7 +9,7 @@
   - To customize, refer to props: https://sa11y.netlify.app/developers/props/
  #}
 
-{% set sa11yVersion = "4.0.9" %}
+{% set sa11yVersion = "4.1.0" %}
 
 {% if settings.env == "dev" %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/ryersondmp/sa11y@{{sa11yVersion}}/dist/css/sa11y.min.css"/>


### PR DESCRIPTION
Do not delete the following line

@netlify /en/pages-to-review/

<div lang="fr">

([Français](#Français))

</div>

_(Pick the language of your choice to fill out the following information.)_

## What does this pull request (PR) do?

This PR adds [Sa11y](https://sa11y.netlify.app/) to the development environment of the DAT. Sa11y will appear on all pages in the bottom right corner, displaying the respective language based on the page's locale. Thanks to @shawnthompson for giving me some implementation tips! 

## Additional information (optional)

### Customizing Sa11y
It's super easy to customize Sa11y via [props.](https://sa11y.netlify.app/developers/props/) For example, if you'd like to ignore the Government of Canada logo on all pages, you can use one of the various ignore props.

For example:

```js
const sa11y = new Sa11y({
  checkRoot: "main",
  imageIgnore: 'img[src*="sig-blk-en.svg"]',
});
``` 

### Related issues
- Discussion item #685 
- Issue #73

### Screenshots

View Netlify deploy link!

</div>
