### PR TITLE
Revert "Use slugify function across Eleventy configuration"

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,7 +10,6 @@ const { stripHtml } = require('string-strip-html');
 const beautify = require('js-beautify').html;
 const { DateTime } = require('luxon');
 const changedPageUrls = [];
-const getSlugify = (eleventyConfig) => eleventyConfig.getFilter("slugify");
 
 // ANSI escape codes for blue underline
 const underline = '\x1b[4m';  // Underline font
@@ -20,7 +19,7 @@ const resetColor = '\x1b[0m'; // Reset font to default
 const isWatchMode = process.env.ELEVENTY_WATCH === 'true';
 
 module.exports = function (eleventyConfig) {
-  const slugify = getSlugify(eleventyConfig);
+  const eleventySlugify = eleventyConfig.getFilter('slug');
 
   let markdownItOptions = {
     html: true, // Enable HTML tags in Markdown
@@ -29,7 +28,7 @@ module.exports = function (eleventyConfig) {
   const md = markdownIt(markdownItOptions)
     .use(markdownItAttrs)
     .use(markdownItAnchor, {
-      slugify: s => slugify(s, { lower: true, strict: true, locale: 'fr' }),
+      slugify: s => eleventySlugify(s, { lower: true, strict: true, locale: 'fr' }),
       permalink: false, // Disable permalinks
     });
 
@@ -45,7 +44,7 @@ module.exports = function (eleventyConfig) {
       const level = token.tag;
       const rawText = tokens[tokens.indexOf(token) + 1].content;
       const text = stripHtml(rawText).result; // Strip HTML tags from the heading text
-      const id = slugify(text, { lower: true, strict: true, locale: 'fr' });
+      const id = eleventySlugify(text, { lower: true, strict: true, locale: 'fr' });
       return { level, text, id };
     });
 
@@ -85,7 +84,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter("stripTagsSlugify", (str) => {
     if (!str) return;
-    return slugify(stripHtml(str).result, { lower: true, strict: true, locale: 'fr' });
+    return eleventySlugify(stripHtml(str).result, { lower: true, strict: true, locale: 'fr' });
   });
 
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);
@@ -170,7 +169,7 @@ module.exports = function (eleventyConfig) {
           const level = token.tag;
           const rawText = tokens[tokens.indexOf(token) + 1].content;
           const text = stripHtml(rawText).result; // Strip HTML tags from the heading text
-          const id = slugify(text, { lower: true, strict: true, locale: 'fr' });
+          const id = eleventySlugify(text, { lower: true, strict: true, locale: 'fr' });
           return { level, text, id };
         });
         item.data.headings = headings;


### PR DESCRIPTION
This reverts commit 955991c61ae62673eed8d4928edc897cf2a0b9bd.

This change broken a lot of the language toggle links
