### PR TITLE
Limit Google Tag Manager script to production domain only

### DIFF
--- a/src/_includes/partials/head.njk
+++ b/src/_includes/partials/head.njk
@@ -63,12 +63,11 @@
 	<script>
 		(function (w) {
 			"use strict";
-			var dl = "dataLayer";
-			if (w.location.hostname === "a11y.canada.ca" || w.location.hostname === "deploy-preview-335--a11ycanada.netlify.app") {
-				w[dl] = w[dl] || [];
+			if (w.location.hostname === "a11y.canada.ca") {
+				w.dataLayer = w.dataLayer || [];
 				w.gtag = function () {
-					w[dl].push(arguments);
-				}
+					w.dataLayer.push(arguments);
+				};
 				w.gtag('js', new Date());
 				w.gtag('config', 'G-SM9MSHWDVN');
 			}


### PR DESCRIPTION
Restrict GTM script execution to a11y.canada.ca to prevent tracking on preview and development environments
