### PR TITLE
Removed one of broken links from the accessible email page in EN and FR

### DIFF
--- a/src/pages/en/making-accessible-emails.md
+++ b/src/pages/en/making-accessible-emails.md
@@ -66,7 +66,6 @@ Avoid overly complex writing styles.
 ### Resources:
 
 - [Canada.ca Content Style Guide—Plain Language](https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-style-guide.html#toc6)
-- <a href="http://en.copian.ca/library/learning/nwt/writread/writefor.pdf" download>Write for your Reader—A plain language handbook</a>
 - <a href="https://www.nwtliteracy.ca/sites/default/files/resources/practice.pdf" download>Putting plain language into practice</a>
 - <a href="https://www.nwtliteracy.ca/sites/default/files/resources/136648a_nwt_literacy_audit_tool.pdf" download>Plain Language Audit Tool—A checklist to review documents</a>
 

--- a/src/pages/fr/rendre-vos-courriels-accessibles.md
+++ b/src/pages/fr/rendre-vos-courriels-accessibles.md
@@ -66,7 +66,6 @@ Si le document entier est en anglais mais que certaines sections renferment des 
 ### Resources
 
 - [Guide de rédaction du contenu du site Canada.ca — Langage clair et simple](https://conception.canada.ca/guide-redaction/#toc6)
-- <a href="http://en.copian.ca/library/learning/nwt/writread/writefor.pdf" download lang="en">Write for your Reader—A plain language handbook<small lang="fr"> (en anglais seulement)</small></a>
 - <a href="https://www.nwtliteracy.ca/sites/default/files/resources/practice.pdf" download lang="en">Putting plain language into practice<small lang="fr"> (en anglais seulement)</small></a>
 - <a href="https://www.nwtliteracy.ca/sites/default/files/resources/136648a_nwt_literacy_audit_tool.pdf" download lang="en">Plain Language Audit Tool—A checklist to review documents<small lang="fr"> (en anglais seulement)</small></a>
 


### PR DESCRIPTION
Do not delete the following line
@netlify /en/pages-to-review/

Removed the broken link from the following pages:
- EN: https://a11y.canada.ca/en/making-accessible-emails/ 
- FR: https://a11y.canada.ca/en/making-accessible-emails/ 

The link of [Write for your Reader—A plain language handbook](http://en.copian.ca/library/learning/nwt/writread/writefor.pdf) under "Resources" section is no longer working. It's either shutdown, renamed or expired.