### PR TITLE
Correction: French Page Now Links to French Version

### DIFF
--- a/src/links/fr/la-loi-sur-l-accessibilite-pour-les-personnes-handicapees-de-l-ontario-2005.md
+++ b/src/links/fr/la-loi-sur-l-accessibilite-pour-les-personnes-handicapees-de-l-ontario-2005.md
@@ -1,7 +1,7 @@
 ---
 title: La Loi sur l'accessibilité pour les personnes handicapées de l'Ontario, 2005
-oneLanguage: true
-redirect: https://www.ontario.ca/page/about-accessibility-laws#section-1
+oneLanguage: false
+redirect: https://www.ontario.ca/fr/page/propos-des-lois-sur-laccessibilite#section-1
 description: Renseignez-vous sur les normes et lois sur l’accessibilité que doivent respecter les organisations de l’Ontario. Consultez les normes, les plans d’action et les rapports d’étape qui nous aident à faire de l’Ontario une province plus accessible et plus inclusive pour les personnes handicapées.
 toggle: the-accessibility-for-ontarians-with-disabilities-act-2005
 tags:


### PR DESCRIPTION
@netlify /en/pages-to-review/

I received the email and was informed that the French page of [Normes d’accessibilité mondiales](https://a11y.canada.ca/fr/normes-daccessibilite-mondiales/) shows an English link with a note saying "en anglais seulement" which means "in English only".

I can confirm that there is a French version of the page. It may have been English-only back then, so I have updated it to include the French link, set OneLanguage to false, and committed the change.