### PR TITLE
Email Changes on the DAT Website

### DIFF
--- a/src/_data/contribute.js
+++ b/src/_data/contribute.js
@@ -1,5 +1,5 @@
 module.exports = {
-	email: "digitala11ytoolkit-boitedoutila11enumerique@ssc-spc.gc.ca",
+	email: "digitala11ytoolkit-boitedoutila11enumerique@csps-efpc.gc.ca",
 	fr: {
 		contribute: "Contribuez à ce projet",
 		small: "sur Github.com",

--- a/src/pages/en/contact-us.md
+++ b/src/pages/en/contact-us.md
@@ -12,7 +12,7 @@ Whether you're curious about the project or would like to provide feedback. Plea
 
 You can get in touch with us through our email address:
 
-- [digitala11ytoolkit-boitedoutila11enumerique@ssc-spc.gc.ca](mailto:digitala11ytoolkit-boitedoutila11enumerique@ssc-spc.gc.ca)
+- [digitala11ytoolkit-boitedoutila11enumerique@csps-efpc.gc.ca](mailto:digitala11ytoolkit-boitedoutila11enumerique@csps-efpc.gc.ca)
 
 However, if you prefer to communicate via GitHub, you're welcome to do so:
 

--- a/src/pages/fr/contactez-nous.md
+++ b/src/pages/fr/contactez-nous.md
@@ -12,7 +12,7 @@ Que vous soyez curieux du projet ou que vous souhaitiez fournir des commentaires
 
 Vous pouvez nous contacter via notre adresse courriel :
 
-- [digitala11ytoolkit-boitedoutila11enumerique@ssc-spc.gc.ca](mailto:digitala11ytoolkit-boitedoutila11enumerique@ssc-spc.gc.ca)
+- [digitala11ytoolkit-boitedoutila11enumerique@csps-efpc.gc.ca](mailto:digitala11ytoolkit-boitedoutila11enumerique@csps-efpc.gc.ca)
 
 Cependant, si vous préférez nous communiquer via GitHub, n'hésitez pas à le faire :
 


### PR DESCRIPTION
@netlify /en/pages-to-review/

Email address changes in both FR and EN pages of the following pages:
- https://a11y.canada.ca/en/contact-us/
- https://a11y.canada.ca/fr/contactez-nous/

And as well as changed the email address under "**Reach the Digital Accessibility Toolkit by email**" for all the contribute sections at the bottom on every page.

<img width="1810" height="472" alt="image" src="https://github.com/user-attachments/assets/8d1e56bf-aeba-492f-a1b1-80138816ce78" />
