### PR TITLE
Page List Link Component

### DIFF
--- a/src/_data/pageList.js
+++ b/src/_data/pageList.js
@@ -9,6 +9,11 @@ module.exports = {
 		filePathText: "Emplacement du fichier",
 		resultsText: "résultats sur",
 		searchText: "Rechercher",
+		// Page list link component
+		linkHeading: "Vous ne trouvez toujours pas ce dont vous avez besoin?",
+		linkText: "liste complète des pages",
+		linkPrefix: "Consultez notre",
+		linkUrl: "/liste-des-pages/",
 	},
 
 	en: {
@@ -21,5 +26,10 @@ module.exports = {
 		filePathText: "File location",
 		resultsText: "results out of",
 		searchText: "Search",
+		// Page list link component
+		linkHeading: "Still can't find what you need?",
+		linkText: "complete list of pages",
+		linkPrefix: "See our",
+		linkUrl: "/page-list/",
 	},
 };

--- a/src/_includes/partials/contribute.njk
+++ b/src/_includes/partials/contribute.njk
@@ -1,28 +1,31 @@
 {% set newPath = page.inputPath | replace("\./", "/") %}
 
-<aside class="contribute">
-	<div class="container">
-		<div class="row">
-			<div class="col-md-5">
-				<h2><i class="fab fa-github fa-lg fa-fw" aria-hidden="true"></i><span>{{ contribute[locale].contribute }}</span><small>{{ contribute[locale].small }}</small></h2>
+<aside>
+	{% include "./pageListLink.njk" %}
+	<div class="contribute">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-5">
+					<h2><i class="fab fa-github fa-lg fa-fw" aria-hidden="true"></i><span>{{ contribute[locale].contribute }}</span><small>{{ contribute[locale].small }}</small></h2>
+				</div>
+				<div class="col-md-7">
+					<ul class="list-inline">
+						<li class="mrgn-rght-sm"><i class="fas fa-code fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == "fr" %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io">{{ contribute[locale].see }}</a></li>
+						<li class="mrgn-rght-sm"><i class="fas fa-exclamation-circle fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == "fr" %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/issues/">{{ contribute[locale].report }}</a></li>
+						<li><i class="fas fa-comments fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == fr %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/discussions">{{ contribute[locale].join }}</a></li>
+					</ul>
+					<p><i class="fas fa-envelope fa-lg fa-fw" aria-hidden="true"></i><a href="mailto:{{ contribute.email }}?subject={{ contribute[locale].emailSubject }}">{{ contribute[locale].emailText }}</a></p>
+				</div>
 			</div>
-			<div class="col-md-7">
-				<ul class="list-inline">
-					<li class="mrgn-rght-sm"><i class="fas fa-code fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == "fr" %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io">{{ contribute[locale].see }}</a></li>
-					<li class="mrgn-rght-sm"><i class="fas fa-exclamation-circle fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == "fr" %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/issues/">{{ contribute[locale].report }}</a></li>
-					<li><i class="fas fa-comments fa-lg fa-fw" aria-hidden="true"></i><a{% if locale == fr %} {% endif %} href="https://github.com/gc-da11yn/gc-da11yn.github.io/discussions">{{ contribute[locale].join }}</a></li>
-				</ul>
-				<p><i class="fas fa-envelope fa-lg fa-fw" aria-hidden="true"></i><a href="mailto:{{ contribute.email }}?subject={{ contribute[locale].emailSubject }}">{{ contribute[locale].emailText }}</a></p>
-			</div>
-		</div>
-		{# This code block checks if the environment is set to "dev". If it is, it displays a paragraph with a link to Netlify and a link to edit the code for the current page on GitHub. #}
-		{% if settings.env == "dev" %}
-			<p>{{ contribute[locale].netlify }} <a{% if locale == "fr" %} {% endif %} href="https://www.netlify.com">Netlify</a></p>
-			{% if locale === 'en' %}
-				<p class="text-center"><a href="https://github.com/gc-da11yn/gc-da11yn.github.io/edit/main{{ newPath }}">Edit code for the <strong>{{ title | safe }}</strong> page</a>.</p>
-			{% else %}
-				<p class="text-center"><a href="https://github.com/gc-da11yn/gc-da11yn.github.io/edit/main{{ newPath }}">Modifier le code de la page <strong>{{ title| safe }}</strong></a>.</p>
+			{# This code block checks if the environment is set to "dev". If it is, it displays a paragraph with a link to Netlify and a link to edit the code for the current page on GitHub. #}
+			{% if settings.env == "dev" %}
+				<p>{{ contribute[locale].netlify }} <a{% if locale == "fr" %} {% endif %} href="https://www.netlify.com">Netlify</a></p>
+				{% if locale === 'en' %}
+					<p class="text-center"><a href="https://github.com/gc-da11yn/gc-da11yn.github.io/edit/main{{ newPath }}">Edit code for the <strong>{{ title | safe }}</strong> page</a>.</p>
+				{% else %}
+					<p class="text-center"><a href="https://github.com/gc-da11yn/gc-da11yn.github.io/edit/main{{ newPath }}">Modifier le code de la page <strong>{{ title| safe }}</strong></a>.</p>
+				{% endif %}
 			{% endif %}
-		{% endif %}
+		</div>
 	</div>
 </aside>

--- a/src/_includes/partials/pageListLink.njk
+++ b/src/_includes/partials/pageListLink.njk
@@ -1,0 +1,14 @@
+{#
+  Page List Link Component
+
+  This global bilingual component displays a call-to-action for users to view the complete list of pages.
+  - Text and URLs are sourced from `src/_data/pageList.js` using the current `locale`.
+  - Uses `{{ pathPrefix }}` and `{{ locale }}` for proper URL construction and deployment compatibility.
+  - Included on every page to improve site navigation and discoverability.
+#}
+<div class="pageList bg-light pb-3">
+    <div class="container">
+        <h2 class="h3">{{ pageList[locale].linkHeading }}</h2>
+        <p><i class="fas fa-search" aria-hidden="true"></i> {{ pageList[locale].linkPrefix }} <a href="{{ pathPrefix }}/{{ locale }}{{ pageList[locale].linkUrl }}">{{ pageList[locale].linkText }}</a>.</p>
+    </div>
+</div>


### PR DESCRIPTION
Add global bilingual Page List Link component and i18n text to pageList.js

- Implements reusable call-to-action for complete page list navigation
- Sources bilingual text and URLs from `pageList.js`
- Follows locale-driven template and pathPrefix patterns for accessibility and deployment
- Documents component usage and architecture in `pageListLink.njk`
