### PR TITLE
[CHANGE] Broken Links Fix

### DIFF
--- a/src/pages/en/designing-accessible-images.md
+++ b/src/pages/en/designing-accessible-images.md
@@ -4,7 +4,7 @@ description: With this diagram, you will learn how to make the best choice for d
 toggle: Concevoir des images accessibles
 ---
 
-<img src="{{ pathPrefix }}img/en/introduction/accessible-image.jpg" class="img-responsive" alt="An infographic on how to use accessible images and use alternative text. Long description below" />
+<img src="{{ pathPrefix }}/img/en/introduction/accessible-image.jpg" class="img-responsive" alt="An infographic on how to use accessible images and use alternative text. Long description below" />
 
 ## The purpose of images
 

--- a/src/pages/fr/bonnes-pratiques-pour-les-evenements-virtuels-accessibles.md
+++ b/src/pages/fr/bonnes-pratiques-pour-les-evenements-virtuels-accessibles.md
@@ -265,7 +265,7 @@ Tout le contenu distribué doit être accessible et dans les deux langues offici
 
 Envisagez de suivre une formation sur l'accessibilité. Lorsque le contenu est élaboré par des personnes qui ont acquis des connaissances en matière d'accessibilité et qui les appliquent dès le départ, cela permet de gagner bien du temps et d'économiser beaucoup d'argent en réduisant la nécessité de prendre des mesures correctives et en évitant les plaintes potentielles.
 
-Veuillez consulter la [boîte à outils de l'accessibilité numérique](https://a11y.canada.ca/fr/guides/) pour obtenir des renseignements plus détaillés dans nos guides. En outre, nous vous recommandons de regarder [l'atelier enregistré de l'EFPC intitulé « Rendre ses documents accessibles (INC1-V46) »](https://www.csps-efpc.gc.ca/video/making-documents-accessible-fra.aspx).
+Veuillez consulter la [boîte à outils de l'accessibilité numérique](https://a11y.canada.ca/fr/) pour obtenir des renseignements plus détaillés dans nos guides. En outre, nous vous recommandons de regarder [l'atelier enregistré de l'EFPC intitulé « Rendre ses documents accessibles (INC1-V46) »](https://www.csps-efpc.gc.ca/video/making-documents-accessible-fra.aspx).
 
 ##### Conseil général sur l'accessibilité des documents (s'applique à tous)
 

--- a/src/pages/fr/concevoir-des-images-accessibles.md
+++ b/src/pages/fr/concevoir-des-images-accessibles.md
@@ -4,7 +4,7 @@ description: Grâce à ce diagramme, vous apprendrez à faire le meilleur choix 
 toggle: Designing accessible images
 ---
 
-<img src="{{ pathPrefix }}img/fr/introduction/image-accessible.jpg" class="img-responsive" alt="Une infographie sur la façon d'utiliser des images accessibles et d'utiliser le texte alternatif. Longue description ci-dessous" />
+<img src="{{ pathPrefix }}/img/fr/introduction/image-accessible.jpg" class="img-responsive" alt="Une infographie sur la façon d'utiliser des images accessibles et d'utiliser le texte alternatif. Longue description ci-dessous" />
 
 ## L'objectif des images
 

--- a/src/pages/fr/diffusions-en-direct.md
+++ b/src/pages/fr/diffusions-en-direct.md
@@ -16,7 +16,7 @@ Les diffusions en direct sont définies comme un animateur qui présente un Powe
 
 - L’animateur doit lire tout ce qui figure sur le PowerPoint présenté;
 - La transcription en direct est recommandée pour un événement en direct. Une version nettoyée comprenant une formulation, une grammaire et une ponctuation correctes de la transcription en direct doit être mise à disposition.
-- Créer une [version accessible de PowerPoint](https://a11y.canada.ca/fr/guides/office365/accessible-powerpoint-documents-365/). Si le présentateur dit chaque mot sur chaque diapositive, on peut l’ignorer, mais ce n’est pas recommandé;
+- Créer une [version accessible de PowerPoint](https://a11y.canada.ca/fr/presentations-powerpoint-accessibles-dans-microsoft-365/). Si le présentateur dit chaque mot sur chaque diapositive, on peut l’ignorer, mais ce n’est pas recommandé;
 - Si l’événement est enregistré, les mêmes règles s’appliquent comme ci-dessus dans la section « Présentation enregistrée »;
 - La langue des signes n’est pas requise.
 

--- a/src/pages/fr/introduction-aux-exigences-daccessibilite-pour-laudio-video.md
+++ b/src/pages/fr/introduction-aux-exigences-daccessibilite-pour-laudio-video.md
@@ -70,7 +70,7 @@ Cela peut être fait en utilisant :
 
 [Directives pour la description sonore]({{ pathPrefix }}/fr/directives-pour-la-description-sonore)
 
-[Liste de contrôle pour la description sonore]({{ pathPrefix }}/fr/directives-pour-la-description-sonore#liste-de-contr%C3%B4le-pour-la-description-sonore)
+[Liste de contrôle pour la description sonore]({{ pathPrefix }}/fr/directives-pour-la-description-sonore/#liste-de-controle-pour-la-description-sonore)
 
 ## Accès au clavier
 


### PR DESCRIPTION
@netlify /en/pages-to-review/

Fixed the broken links of the following:

- https://a11y.canada.ca/en/designing-accessible-images/img/en/introduction/accessible-image.jpg (error 404 - missing image)
- https://a11y.canada.ca/fr/guides/ (error 404 - missing page)
- https://a11y.canada.ca/fr/concevoir-des-images-accessibles/img/fr/introduction/image-accessible.jpg (error 404 - missing image)
- https://a11y.canada.ca/fr/guides/office365/accessible-powerpoint-documents-365/ (error 404 - missing page)
- [https://a11y.canada.ca/fr/directives-pour-la-description-sonore#liste-de-contr%C3%B4le-pour-la-desc…](https://a11y.canada.ca/fr/directives-pour-la-description-sonore#liste-de-contr%C3%B4le-pour-la-description-sonore) (null error)

See the changes below to compare. 