### PR TITLE
fix(toc): synchronize TOC anchor generation with markdown plugin

### DIFF
--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,5 +1,6 @@
 const pathPrefix = require('./pathPrefix')(); // resolve once per build
 const fs = require('fs');
+const { stripHtml } = require('string-strip-html');
 
 module.exports = {
 	eleventyExcludeFromCollections(data) {
@@ -39,13 +40,30 @@ module.exports = {
                 const level = match[1].length; // Number of # characters
                 const text = match[2].trim();
 
-                // Create ID from heading text (similar to markdown-it-anchor)
-                const id = text
+                // Create ID from heading text using the same logic as markdown-it-anchor
+                // This matches the slugification in both the markdown plugin and stripTagsSlugify filter
+                let cleanText = stripHtml(text).result;
+
+                // French accent transliteration (matching stripTagsSlugify filter)
+                cleanText = cleanText
+                    .replace(/[àáâãäå]/g, 'a')
+                    .replace(/[èéêë]/g, 'e')
+                    .replace(/[ìíîï]/g, 'i')
+                    .replace(/[òóôõö]/g, 'o')
+                    .replace(/[ùúûü]/g, 'u')
+                    .replace(/[ýÿ]/g, 'y')
+                    .replace(/[ñ]/g, 'n')
+                    .replace(/[ç]/g, 'c')
+                    .replace(/[æ]/g, 'ae')
+                    .replace(/[œ]/g, 'oe');
+
+                // Standard slugification (matching markdown plugin)
+                const id = cleanText
                     .toLowerCase()
-                    .replace(/[^\w\s-]/g, '') // Remove special characters
-                    .replace(/\s+/g, '-')      // Replace spaces with dashes
-                    .replace(/-+/g, '-')       // Replace multiple dashes with single dash
-                    .replace(/^-|-$/g, '');    // Remove leading/trailing dashes
+                    .trim()
+                    .replace(/[^\w\s-]/g, '') // Remove remaining special characters
+                    .replace(/[\s_-]+/g, '-') // Replace spaces and underscores with hyphens
+                    .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
 
                 // Filter based on TOC settings
                 const minLevel = 2;

--- a/src/_includes/partials/pageList.njk
+++ b/src/_includes/partials/pageList.njk
@@ -134,7 +134,7 @@
 							<p>{% if settings.env == "local" %}<strong>{{ pageList[locale].descriptionText }}{% if locale === "fr" %} {% endif %}: </strong>{% endif %}{% if entry.data.description %}{{ entry.data.description | striptags(true) | escape | nl2br }}{% else %} <span class="label label-danger">{{ landingPage[locale].descriptionNoneText }}</span>{% endif %}</p>
 							{% if settings.env == "local" %}<p><strong>{{ pageList[locale].pathText }}{% if locale === "fr" %} {% endif %}:</strong> <code>{{ entry.url }}</code></p>{% endif %}
 							{% if settings.env == "local" %}<p><strong>{{ pageList[locale].filePathText }}{% if locale === "fr" %} {% endif %}:</strong> <code><a href="https://github.com/gc-da11yn/gc-da11yn.github.io/tree/{{ branch }}{{ newPath }}">{{ newPath }}</a></code></p>{% endif %}
-							{% if settings.env == "local" %}<p><strong>toggle{% if locale === "fr" %} {% endif %}:</strong> <code><a href="{{ pathPrefix }}/{{ otherLang }}/{{ entry.data.toggle | stripTagsSlugify }}/">{{ entry.data.toggle }}</a></code></p>{% endif %}
+							{% if settings.env == "local" %}<p><strong>toggle{% if locale === "fr" %} {% endif %}:</strong> <code><a href="{{ pathPrefix }}/{{ otherLang }}/{% if entry.data.tags != "home"%}{{ entry.data.toggle | stripTagsSlugify }}/{% endif %}">{{ entry.data.toggle }}</a></code></p>{% endif %}
 						</section>
 					{% endif %}
 				{% endif %}

--- a/src/pages/en/best-practices-for-accessible-virtual-events.md
+++ b/src/pages/en/best-practices-for-accessible-virtual-events.md
@@ -13,22 +13,8 @@ hasDocument:
   sizeUnit: KB
   type: word
 internalLinks: true
+toc: true
 ---
-
-## On this page
-
-- [Introduction](#introduction)
-  - [Common issues reported by people with disabilities](#common-issues-reported-by-people-with-disabilities)
-  - [Canadian legal framework for accessible events](#canadian-legal-framework-for-accessible-events)
-  - [Facts to keep in mind](#facts-to-keep-in-mind)
-- [Virtual events](#virtual-events)
-  - [Roadmap](#roadmap)
-  - [Plan the event: 1 to 2 months before the event (approximately)](#plan-the-event-1-to-2-months-before-the-event-approximately)
-  - [Get ready: 1 to 2 weeks before the event (approximately)](#get-ready-1-to-2-weeks-before-the-event-approximately)
-  - [Day of the event](#day-of-the-event)
-  - [After the event](#after-the-event)
-  - [For reference: What will affect your budget](#for-reference-what-will-affect-your-budget)
-  - [For reference: Virtual platforms](#for-reference-virtual-platforms)
 
 ## Introduction
 

--- a/src/pages/fr/bonnes-pratiques-pour-les-evenements-virtuels-accessibles.md
+++ b/src/pages/fr/bonnes-pratiques-pour-les-evenements-virtuels-accessibles.md
@@ -13,23 +13,8 @@ hasDocument:
   sizeUnit: KB
   type: word
 internalLinks: true
+toc: true
 ---
-
-## Sur cette page
-
-- [Introduction](#introduction)
-  - [Problèmes courants signalés par les personnes en situation de handicap](#problemes-courants-signales-par-les-personnes-en-situation-de-handicap)
-  - [Mobilité](#mobilite)
-  - [Cadre juridique canadien pour l'accessibilité des événements](#cadre-juridique-canadien-pour-laccessibilite-des-evenements)
-  - [Faits à retenir](#faits-a-retenir)
-- [Événements virtuels](#evenements-virtuels)
-  - [Feuille de route](#feuille-de-route)
-  - [Planification de l’événement : un à deux mois avant la tenue de l'événement (environ)](#planification-de-levenement-un-a-deux-mois-avant-la-tenue-de-levenement-environ)
-  - [Préparez-vous : une à deux semaines avant l'événement (environ)](#preparez-vous-une-a-deux-semaines-avant-levenement-environ)
-  - [Animez l'événement : jour de l'événement](#animez-levenement-jour-de-levenement)
-  - [Après l'événement](#apres-levenement)
-  - [À titre de référence : Ce qui affectera votre budget](#a-titre-de-reference-ce-qui-affectera-votre-budget)
-  - [À titre de référence : Plateformes virtuelles](#a-titre-de-reference-plateformes-virtuelles)
 
 ## Introduction
 
@@ -336,7 +321,7 @@ Veillez à inclure les renseignements suivants dans votre invitation à l'évén
 - Envoyez à l'avance le contenu de l'engagement, comme les sondages et les enquêtes, afin de donner aux personnes en situation de handicap le temps de le consulter, d'y accéder et de participer pendant l'événement;
 - Décrivez brièvement les objectifs de l'événement et clarifiez les sujets de discussion (par exemple, vous pourriez utiliser une à trois puces);
 - Mentionnez si la session sera enregistrée;
-- Partagez l’ébauche de [l’ordre du jour de l’événement](#etablissez-un-ordre-du-jour);
+- Partagez l’ébauche de [l’ordre du jour de l’événement](#tablissez-un-ordre-du-jour);
 - Proposez plusieurs moyens de participer à l'événement, tels que :
   - un lien en ligne;
   - un numéro d'accès direct.
@@ -344,7 +329,7 @@ Veillez à inclure les renseignements suivants dans votre invitation à l'évén
 - Indiquez les coordonnées des personnes à contacter pour les demandes de mesures d’adaptation et une date limite de soumission
   - Ajoutez des exemples de demandes de mesures d’adaptation, car souvent les personnes qui ont besoin de mesures d’adaptation n'osent pas en faire la demande
   - **Rappel :** Les personnes en situation de handicap ne sont pas tenues de divulguer leur handicap à qui que ce soit
-- Incluez des renseignements sur l’utilisation de la plateforme - consultez la [section sur les plateformes virtuelles pour l'organisation d'événements](#a-titre-de-reference-plateformes-virtuelles)
+- Incluez des renseignements sur l’utilisation de la plateforme - consultez la [section sur les plateformes virtuelles pour l'organisation d'événements](#titre-de-reference-plateformes-virtuelles)
 - Fournissez un point de contact pour permettre aux participants de poser des questions et de faire des commentaires à l'avance
 - Évitez les systèmes d'inscription
   - L'inscription peut devenir un obstacle; voyez s'il existe des solutions de rechange pour rendre l'événement plus inclusif. Si l'inscription est obligatoire, collaborez avec le coordinateur de l'événement pour la rendre simple et conforme aux [Règles pour l'accessibilité des contenus Web (<abbr>WCAG</abbr>) 2.1](https://www.w3.org/Translations/WCAG21-fr/)
@@ -412,7 +397,7 @@ Si une répétition est jugée souhaitable, nous recommandons vivement de la fai
 #### Commencez l'événement!
 
 - Si vous enregistrez l'événement, veillez à en informer les participants à l'avance
-- Si l'événement est bilingue, suivez les recommandations de la [section sur les évènements bilingues](#evenement-bilingue-meilleur-choix-pour-les-langues-officielles)
+- Si l'événement est bilingue, suivez les recommandations de la [section sur les évènements bilingues](#venement-bilingue-meilleur-choix-pour-les-langues-officielles)
 - L'hôte lit les textes pour accueillir les participants
 - Présentez les interprètes en langue des signes afin que les utilisateurs qui dépendent d’eux puissent mettre en place leurs mesures d’adaptation en utilisant la plateforme
   - [Microsoft Teams dispose d'un paramètre d'accessibilité permettant de mettre en place des interprètes en langue des signes](https://support.microsoft.com/fr-fr/office/utiliser-la-vue-langue-des-signes-dans-microsoft-teams-c6c11f67-0747-4598-ac27-c90801b94434)


### PR DESCRIPTION
- Add stripHtml() dependency to eleventyComputed.js for proper HTML tag removal
- Implement matching slugification logic for TOC anchors and actual heading IDs
- Include French accent transliteration to match stripTagsSlugify filter
- Update slugification pattern to use same regex as markdown-it-anchor plugin
- Fix TOC link mismatches where HTML entities weren't properly stripped
- Replace manual TOC sections with automated toc: true in event pages
- Fix broken anchor links in French virtual events page

Resolves issue where TOC generated incorrect anchors like:
- TOC link: #sample-of-government-of-canada-abbrgcabbr-employee-personas-with-disabilities
- Actual ID: #sample-of-government-of-canada-gc-employee-personas-with-disabilities

Now both use consistent HTML stripping and slugification for proper navigation.
