### PR TITLE
fix: exclude Decap CMS resources and redirect links from build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -337,6 +337,13 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.ignores.add("src/pages/_template.md");
   eleventyConfig.ignores.add("src/links/_template.md");
 
+  // Ignore Decap CMS resource files - these should not be built as pages
+  // Resources are managed exclusively through Decap CMS and displayed via the template
+  eleventyConfig.ignores.add("src/resources/**/*.md");
+
+  // Ignore redirect link files - these are redirect-only files, not content pages
+  eleventyConfig.ignores.add("src/links/**/*.md");
+
 
 
   // Phase 2: Git operations cache management and debugging


### PR DESCRIPTION
Fixes #760

@netlify /en/pages-to-review/

<div lang="fr">

([Français](#Français))

</div>

_(Pick the language of your choice to fill out the following information.)_

## What does this pull request (PR) do?

This PR excludes Decap CMS resource files and redirect link files from being built as standalone HTML pages. 

- Added ignores pattern for `src/resources/**/*.md` to prevent Markdown files in the resources directory from being built as standalone HTML pages
- Resources are now exclusively managed through Decap CMS and displayed via the template
- Added ignores pattern for `src/links/**/*.md` to prevent redirect-only link files from being built as pages
- The `_site/resources` and `_site/links` directories are no longer created during build

## Additional information (optional)

### General checklist

- [x] Build and test PR's code
- [x] Validate changes against WCAG for accessibility

### Related issues

Closes #760

### Screenshots

N/A

---

<div lang="fr">

## Français

_(Choisissez la langue de votre choix pour remplir l'information ci-dessous.)_

## Que fait cette demande « pull » (PR)?

Cette PR exclut les fichiers de ressources Decap CMS et les fichiers de liens de redirection d'être construits comme des pages HTML autonomes.

- Ajout d'un modèle d'ignorance pour `src/resources/**/*.md` pour empêcher que les fichiers Markdown du répertoire des ressources ne soient construits comme des pages HTML autonomes
- Les ressources sont maintenant gérées exclusivement via Decap CMS et affichées via le modèle
- Ajout d'un modèle d'ignorance pour `src/links/**/*.md` pour empêcher que les fichiers de liens de redirection ne soient construits comme des pages
- Les répertoires `_site/resources` et `_site/links` ne sont plus créés lors de la compilation

## Information additionnelle (optionel)

### Liste de contrôle générale

- [x] Rouler le script de compilation et tester le code de la PR
- [x] Valider les changements avec WCAG pour l'accessibilité

### Requêtes associées

Ferme #760

### Captures d'écrans

S/O

</div>