### PR TITLE
Fix Word paragraph toolbar image

### DIFF
--- a/src/pages/en/ms-office/365/accessible-word-documents-in-microsoft-365.md
+++ b/src/pages/en/ms-office/365/accessible-word-documents-in-microsoft-365.md
@@ -130,7 +130,7 @@ To create a list:
 
 <div class="row">
 <div class="col-md-6">
-mg  src="{{ pathPrefix }}/img/en/office365/word-365-006.jpg" alt="Screenshot of Paragraph toolbar">
+<img class="img-responsive" src="{{ pathPrefix }}/img/en/office365/word-365-006.jpg" alt="Screenshot of Paragraph toolbar">
 </div>
 </div>
 


### PR DESCRIPTION
@netlify /en/pages-to-review/

## Summary

- Restores the broken image tag for the Word 365 paragraph toolbar screenshot.
- Keeps the existing `pathPrefix` image path and alt text so the page continues to work on the main site and forks.
- Limits the change to the affected English Microsoft 365 Word page.

## Validation

- Passed: `npm ci --prefer-offline --no-audit --fund=false`
- Passed: `npm run build`
- Passed: confirmed the built page contains `<img class="img-responsive" src="/img/en/office365/word-365-006.jpg" alt="Screenshot of Paragraph toolbar">`
- Passed: confirmed `src/_images/en/office365/word-365-006.jpg` and `_site/img/en/office365/word-365-006.jpg` exist
- Passed: `git diff --check`
- Not passing in this Windows environment: `npm test -- --runInBand`
  - Integration/performance tests call Unix shell commands such as `rm -rf` and `timeout 30s ... || true`, which are not available here.
  - Existing unit tests for `eleventy/config/filters.js` fail because the test mock lacks `eleventyConfig.addGlobalData`.
- Not passing in this environment: `npm run spellcheck:changed`
  - The script exits at `chalk.red is not a function` under Node v22.13.1; the repository `.nvmrc` specifies Node 20, but Node 20 is not installed on this machine.

## Notes

- Closes #787.
- No compatibility impact expected; this only restores an intended image element around an existing asset.
- No follow-up work required for this specific broken image.
